### PR TITLE
[DMWCOMM-5] 버튼 컴포넌트 체계 통합

### DIFF
--- a/src/app/(with-header)/team/page.tsx
+++ b/src/app/(with-header)/team/page.tsx
@@ -121,9 +121,11 @@ export default function Team() {
               />
             ))}
           </div>
-          <button className="rounded-full bg-gray100 px-4 py-3 flex text-medium16 w-max">
-            벨로그 보러가기
-          </button>
+          <Button
+            text="벨로그 보러가기"
+            style="neutral"
+            className="w-max rounded-full px-4 py-3 text-medium16"
+          />
         </div>
         <div className="w-full px-12 py-24 gap-12 flex flex-col">
           <div className="flex flex-col gap-6">
@@ -171,9 +173,11 @@ export default function Team() {
           <br />
           고개를 들어주세요.
         </p>
-        <button className="bg-gray900 text-medium16 text-white rounded-full px-4 py-3">
-          대마위키 살펴보기
-        </button>
+        <Button
+          text="대마위키 살펴보기"
+          style="dark"
+          className="rounded-full px-4 py-3 text-medium16"
+        />
       </div>
     </div>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Button } from "@/components";
 import { useRouter } from "next/navigation";
 import React from "react";
 
@@ -7,7 +8,7 @@ export default function NotFound() {
   return (
     <div className="w-full h-screen flex items-center justify-center">
       <p>돌아가.</p>
-      <button onClick={() => router.back()}>뒤로 가기</button>
+      <Button onClick={() => router.back()} text="뒤로 가기" style="primary2" />
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 interface ButtonProps {
   text?: string;
-  style?: "primary" | "primary2" | "white";
+  style?: "primary" | "primary2" | "white" | "neutral" | "dark";
   state?: "enabled" | "disabled";
   onClick?: () => void;
   big?: boolean;
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+  className?: string;
   children?: Readonly<React.ReactNode>;
 }
 
@@ -15,25 +18,51 @@ export const Button = ({
   style = "primary",
   state = "enabled",
   big,
+  type = "button",
+  disabled = false,
+  className = "",
   children,
 }: ButtonProps) => {
+  const isDisabled = state === "disabled" || disabled;
+
   const buttonStyle = {
-    primary: { enabled: "text-lime500 bg-white hover:bg-gray50", disabled: "" },
-    primary2: {
-      enabled: "text-white bg-lime500 hover:bg-lime600",
-      disabled: "",
+    primary: {
+      enabled: "bg-white text-lime500 hover:bg-gray50",
+      disabled: "bg-white text-gray400",
     },
-    white: { enabled: "", disabled: "" },
+    primary2: {
+      enabled: "bg-lime500 text-white hover:bg-lime600",
+      disabled: "bg-lime300 text-white",
+    },
+    white: {
+      enabled: "bg-white text-gray600 hover:bg-gray50",
+      disabled: "bg-white text-gray400",
+    },
+    neutral: {
+      enabled: "bg-gray100 text-gray700 hover:bg-gray200",
+      disabled: "bg-gray100 text-gray400",
+    },
+    dark: {
+      enabled: "bg-gray900 text-white hover:bg-black",
+      disabled: "bg-gray400 text-white",
+    },
   };
+
   return (
-    <>
-      <button
-        onClick={onClick}
-        className={`transition-all justify-center items-center gap-1 flex  ${big ? "rounded-lg p-4 text-semibold18" : "px-3 py-2 rounded-md text-semibold16"} ${buttonStyle[style][state]}`}
-      >
-        {text}
-        {children}
-      </button>
-    </>
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={isDisabled}
+      className={`inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap transition-all ${
+        big
+          ? "rounded-lg p-4 text-semibold18"
+          : "rounded-md px-3 py-2 text-semibold16"
+      } ${buttonStyle[style][isDisabled ? "disabled" : "enabled"]} ${
+        isDisabled ? "cursor-not-allowed" : "cursor-pointer"
+      } ${className}`}
+    >
+      {text}
+      {children}
+    </button>
   );
 };

--- a/src/components/edit/EditModal.tsx
+++ b/src/components/edit/EditModal.tsx
@@ -8,6 +8,7 @@ import {
   Text_Strikethrough,
   Text_Underline,
 } from "@/assets";
+import { Button } from "@/components";
 import React from "react";
 
 const icons = [
@@ -42,13 +43,13 @@ function EditModal() {
             ))}
           </div>
           <div className="flex w-full items-center justify-end">
-            <button
-              type="button"
-              className="flex h-fit items-center gap-2 rounded-md bg-lime500 px-4 py-1.5 hover:bg-lime600"
+            <Button
+              text="저장"
+              style="primary2"
+              className="h-fit gap-2 px-4 py-1.5"
             >
-              <p className="text-white text-md font-semibold">저장</p>
               <Document size={20} className="text-white"></Document>
-            </button>
+            </Button>
           </div>
         </div>
         <div className="flex w-full flex-col gap-6 px-12 pt-6 pb-12">


### PR DESCRIPTION
## Summary
- `src/components/Button.tsx`의 API를 확장해 variant(`neutral`, `dark`), `type`, `disabled`, `className`을 지원하도록 공용화했습니다.
- Team 페이지와 NotFound, EditModal의 raw `<button>`을 `Button` 컴포넌트로 치환해 액션 스타일/동작을 통일했습니다.
- 현재 브랜치 기준 `src` 내 raw 버튼은 특수 케이스(토스트 닫기, 링크 블록, 테이블 삭제)를 제외하고 정리되었습니다.

## Verification
- `lsp_diagnostics` clean:
  - `src/components/Button.tsx`
  - `src/app/(with-header)/team/page.tsx`
  - `src/app/not-found.tsx`
  - `src/components/edit/EditModal.tsx`
- `corepack yarn tsc --noEmit` 실행 시 기존 pre-existing 타입 오류(division/userInfo/recent)로 실패