### PR TITLE
[DMWCOMM-1] 페이지 컨테이너 폭/패딩 기준 일원화

### DIFF
--- a/src/app/(with-header)/division/page.tsx
+++ b/src/app/(with-header)/division/page.tsx
@@ -5,7 +5,7 @@ import StudentPage from "./student/page";
 export default function Division() {
   return (
     <div className="w-full flex justify-center pb-12">
-      <div className="w-full pt-16 px-12 max-w-[1200px] flex flex-col gap-14">
+      <div className="flex w-full max-w-screen-xl flex-col gap-14 px-12 pt-16">
         <Title
           noPadding
           noShow

--- a/src/app/(with-header)/division/student/page.tsx
+++ b/src/app/(with-header)/division/student/page.tsx
@@ -15,7 +15,7 @@ function StudentPage() {
   });
   return (
     <div className="w-full flex justify-center">
-      <div className="flex flex-col w-full max-w-[1200px]">
+      <div className="flex w-full max-w-screen-xl flex-col">
         <div className="flex w-full flex-col gap-3 pb-12 pt-28">
           <div className="rounded-md p-2 w-fit border border-gray200 bg-white hover:bg-gray50">
             <Arrow className="text-gray600" />

--- a/src/app/(with-header)/document/[id]/page.tsx
+++ b/src/app/(with-header)/document/[id]/page.tsx
@@ -23,13 +23,18 @@ function Document() {
       title: "오타쿠",
       details: "이상한 걸 좋아한다.",
     },
-    { num: "5", title: "망언록", details: "“너무나도 청렴한 사람이라 명언록만 있지, 망언록은 존재하지 않는다.”" },
+    {
+      num: "5",
+      title: "망언록",
+      details:
+        "“너무나도 청렴한 사람이라 명언록만 있지, 망언록은 존재하지 않는다.”",
+    },
   ];
   return (
     <div
       className={`${openSidebar ? "pl-[300px]" : "pl-6"} transition-all pt-20 pb-20 pr-6 bg-gray100 justify-center flex w-full min-h-screen`}
     >
-      <div className="max-w-[1200px] w-full flex flex-col rounded-2xl bg-white border border-gray200 overflow-hidden">
+      <div className="flex w-full max-w-screen-xl flex-col overflow-hidden rounded-2xl border border-gray200 bg-white">
         <Title />
         <Profile />
         <div className="w-full px-12 py-6">

--- a/src/app/(with-header)/document/[id]/userInfo/page.tsx
+++ b/src/app/(with-header)/document/[id]/userInfo/page.tsx
@@ -71,7 +71,7 @@ export default function UserInfo() {
   return (
     <div className="flex justify-center pt-16">
       <Sidebar fixed />
-      <div className="flex flex-col max-w-[1200px] flex-grow">
+      <div className="flex flex-grow max-w-screen-xl flex-col">
         <Title />
         <div className="flex flex-col py-6 px-12 gap-20">
           <div className="flex gap-20">
@@ -157,7 +157,7 @@ export default function UserInfo() {
           </div>
         </div>
       </div>
-      <section className="max-w-[1200px]"></section>
+      <section className="max-w-screen-xl"></section>
     </div>
   );
 }

--- a/src/app/(with-header)/recent/page.tsx
+++ b/src/app/(with-header)/recent/page.tsx
@@ -12,7 +12,7 @@ function Recent() {
   });
   return (
     <div className="w-full flex justify-center pb-12">
-      <div className="w-full pt-16 px-12 max-w-[1200px] flex flex-col gap-14">
+      <div className="flex w-full max-w-screen-xl flex-col gap-14 px-12 pt-16">
         <Title
           noPadding
           noShow

--- a/src/app/(with-header)/team/page.tsx
+++ b/src/app/(with-header)/team/page.tsx
@@ -59,7 +59,7 @@ export default function Team() {
   const router = useRouter();
   return (
     <div className="w-full flex justify-center flex-col">
-      <div className="w-full max-w-[1200px] flex flex-col pt-16">
+      <div className="flex w-full max-w-screen-xl flex-col pt-16">
         <div className="w-full px-12 py-24 gap-6 flex justify-between">
           <div className="flex flex-col gap-6 bg-white">
             <p className="text-bold40">


### PR DESCRIPTION
## Summary
- 목록형 페이지(`division`, `division/student`, `recent`, `team`)의 컨테이너 폭을 `max-w-screen-xl` 기준으로 통일했습니다.
- 문서 상세 계열(`document/[id]`, `document/[id]/userInfo`)도 동일한 폭 기준으로 정렬해 페이지 리듬을 맞췄습니다.
- 클래스 순서와 레이아웃 선언을 정리해 공통 패턴(`flex w-full max-w-screen-xl ...`)으로 가독성을 개선했습니다.

## Verification
- `lsp_diagnostics` clean on changed files
- `corepack yarn tsc --noEmit` 실행 시 기존 pre-existing 타입 오류(Title/Sidebar props)로 실패