### PR TITLE
[DMWCOMM-7] 입력/폼 필드 스타일 공통화

### DIFF
--- a/src/app/(with-header)/login/page.tsx
+++ b/src/app/(with-header)/login/page.tsx
@@ -2,6 +2,15 @@
 import React from "react";
 import { Arrow } from "@/assets";
 import { Button, RegisterInput, useToast } from "@/components";
+import {
+  authBackButtonClass,
+  authBottomBlockClass,
+  authDescriptionClass,
+  authFormLayoutClass,
+  authFormPanelClass,
+  authInfoBlockClass,
+  authTitleBlockClass,
+} from "@/constant/formStyle";
 import { useRouter } from "next/navigation";
 import { Controller, useForm } from "react-hook-form";
 import { LoginValues } from "@/interfaces/user";
@@ -43,18 +52,15 @@ export default function Login() {
   });
 
   return (
-    <div className="w-full h-screen flex justify-center pt-6">
-      <div className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl">
-        <div
-          onClick={() => router.back()}
-          className="rounded-md w-fit border border-gray200 p-2 flex bg-white hover:bg-gray50"
-        >
+    <div className={authFormLayoutClass}>
+      <div className={authFormPanelClass}>
+        <div onClick={() => router.back()} className={authBackButtonClass}>
           <Arrow size={28} className="text-gray600" />
         </div>
-        <div className="w-full flex flex-col gap-6">
-          <div className="w-full flex flex-col gap-3">
+        <div className={authInfoBlockClass}>
+          <div className={authTitleBlockClass}>
             <p className="text-bold36 text-black">로그인</p>
-            <p className="text-gray500 text-medium18">
+            <p className={authDescriptionClass}>
               대마고에서 일어나는 모든 일을 이곳에서
             </p>
           </div>
@@ -95,7 +101,7 @@ export default function Login() {
             />
           </div>
         </div>
-        <div className="w-full flex flex-col gap-6">
+        <div className={authBottomBlockClass}>
           <div className="flex gap-1.5">
             <p className="text-medium16 text-gray600">계정이 없으신가요?</p>
             <p

--- a/src/app/(with-header)/signup/Register.tsx
+++ b/src/app/(with-header)/signup/Register.tsx
@@ -1,7 +1,11 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import { Button, RegisterInput } from "@/components";
-import { useRouter } from "next/navigation";
+import {
+  formFieldErrorClass,
+  otpCellClass,
+  otpInputClass,
+} from "@/constant/formStyle";
 import { periodMenu, majorMenu } from "@/constant/dropdownItem";
 import { Controller, FieldErrors, Control, useWatch } from "react-hook-form";
 import { SignupFormValues } from "@/interfaces/user";
@@ -102,23 +106,20 @@ export const EmailVerification = ({ control, errors }: SignupFormProps) => {
         <div className="w-full flex flex-col gap-3">
           <div className="w-full flex gap-2 justify-center">
             {verificationCode.map((code, index) => (
-              <div
-                key={index}
-                className="w-16 h-16 focus-within:bg-white bg-gray50 rounded-lg flex justify-center items-center border border-gray300"
-              >
+              <div key={index} className={otpCellClass}>
                 <input
                   value={code}
                   onChange={e => handleChange(e, index, onChange)}
                   onKeyDown={e => handleKeyDown(e, index)}
                   ref={e => inputRefEvent(e, index)}
                   maxLength={1}
-                  className="text-center text-black text-semibold24 bg-transparent w-full"
+                  className={otpInputClass}
                 />
               </div>
             ))}
           </div>
           <div className="w-full flex justify-between">
-            <p className="text-medium14 text-red500 ml-2">
+            <p className={`${formFieldErrorClass} ml-2`}>
               {errors.verificationCode?.message}
             </p>
             <Button onClick={reSendMail} style="primary2" text="재전송" />

--- a/src/app/(with-header)/signup/page.tsx
+++ b/src/app/(with-header)/signup/page.tsx
@@ -1,7 +1,16 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { Arrow } from "@/assets";
-import { Button, RegisterInput } from "@/components";
+import { Button } from "@/components";
+import {
+  authBackButtonClass,
+  authBottomBlockClass,
+  authDescriptionClass,
+  authFormLayoutClass,
+  authFormPanelClass,
+  authInfoBlockClass,
+  authTitleBlockClass,
+} from "@/constant/formStyle";
 import { useRouter } from "next/navigation";
 import { Email, EmailVerification, Name, Password } from "./Register";
 import { useForm, useWatch } from "react-hook-form";
@@ -16,7 +25,6 @@ export default function Signup() {
     control,
     handleSubmit,
     formState: { errors },
-    reset,
   } = useForm<SignupFormValues>({
     defaultValues: {
       name: "",
@@ -121,24 +129,19 @@ export default function Signup() {
   }, [nextStep]);
 
   return (
-    <div className="w-full h-screen flex justify-center pt-6">
-      <div className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl">
-        <div
-          onClick={() => prevStep()}
-          className="rounded-md w-fit border border-gray200 p-2 flex bg-white hover:bg-gray50"
-        >
+    <div className={authFormLayoutClass}>
+      <div className={authFormPanelClass}>
+        <div onClick={() => prevStep()} className={authBackButtonClass}>
           <Arrow size={28} className="text-gray600" />
         </div>
-        <div className="w-full flex flex-col gap-6">
-          <div className="w-full flex flex-col gap-3">
+        <div className={authInfoBlockClass}>
+          <div className={authTitleBlockClass}>
             <p className="text-bold36 text-black">회원가입</p>
-            <p className="text-gray500 text-medium18">
-              {page[pageNum].details}
-            </p>
+            <p className={authDescriptionClass}>{page[pageNum].details}</p>
           </div>
           {page[pageNum].page}
         </div>
-        <div className="w-full flex flex-col gap-6">
+        <div className={authBottomBlockClass}>
           <div className="w-full gap-2 flex justify-center items-center">
             {page.map((_, index) => (
               <div

--- a/src/components/RegisterInput.tsx
+++ b/src/components/RegisterInput.tsx
@@ -1,5 +1,14 @@
 "use client";
 import { Arrow, Hide, Show } from "@/assets";
+import {
+  formFieldContainerClass,
+  formFieldDropdownTextClass,
+  formFieldErrorClass,
+  formFieldInputClass,
+  formFieldInputRowClass,
+  formFieldLabelClass,
+  formFieldWrapperClass,
+} from "@/constant/formStyle";
 import React, { useState, useEffect, useRef } from "react";
 
 interface InputProps {
@@ -80,17 +89,15 @@ export const RegisterInput = ({
   };
 
   return (
-    <div className="flex flex-col w-full gap-2" ref={inputRef}>
-      <div className="rounded-lg focus-within:border-lime500 overflow-hidden flex flex-col w-full border border-gray200">
-        <div className="w-full px-3 pt-3 flex text-gray600 text-semibold16">
-          {title}
-        </div>
+    <div className={formFieldContainerClass} ref={inputRef}>
+      <div className={formFieldWrapperClass}>
+        <div className={formFieldLabelClass}>{title}</div>
         <div
           onClick={() => type === "dropdown" && setDropdownOpen(!dropdownOpen)}
-          className="gap-2 flex w-full items-center"
+          className={formFieldInputRowClass}
         >
           {type === "dropdown" ? (
-            <div className="w-full cursor-pointer flex p-3 text-medium20 text-gray800">
+            <div className={formFieldDropdownTextClass}>
               {value || placeholder}
             </div>
           ) : (
@@ -100,14 +107,14 @@ export const RegisterInput = ({
               onChange={e => onChange?.(e.target.value)}
               type={hidePassword && type === "password" ? "password" : "text"}
               placeholder={placeholder}
-              className="w-full p-3 placeholder:text-gray300 text-medium20"
+              className={formFieldInputClass}
             />
           )}
           {inputType[type]}
         </div>
       </div>
 
-      <p className="text-medium14 text-red500 relative">
+      <p className={formFieldErrorClass}>
         {error}
         {type === "dropdown" && dropdownOpen && (
           <div className="top-0 z-10 rounded-lg bg-white border border-gray200 shadow-lg overflow-y-scroll absolute w-[432px] h-36 flex flex-col">

--- a/src/constant/formStyle.ts
+++ b/src/constant/formStyle.ts
@@ -1,0 +1,39 @@
+export const authFormLayoutClass = "flex h-screen w-full justify-center pt-6";
+
+export const authFormPanelClass =
+  "flex w-[480px] flex-col gap-12 rounded-3xl p-6";
+
+export const authBackButtonClass =
+  "flex w-fit rounded-md border border-gray200 bg-white p-2 hover:bg-gray50";
+
+export const authInfoBlockClass = "flex w-full flex-col gap-6";
+
+export const authTitleBlockClass = "flex w-full flex-col gap-3";
+
+export const authDescriptionClass = "text-medium18 text-gray500";
+
+export const authBottomBlockClass = "flex w-full flex-col gap-6";
+
+export const formFieldContainerClass = "flex w-full flex-col gap-2";
+
+export const formFieldWrapperClass =
+  "flex w-full flex-col overflow-hidden rounded-lg border border-gray200 focus-within:border-lime500";
+
+export const formFieldLabelClass =
+  "flex w-full px-3 pt-3 text-semibold16 text-gray600";
+
+export const formFieldInputRowClass = "flex w-full items-center gap-2";
+
+export const formFieldInputClass =
+  "w-full p-3 text-medium20 placeholder:text-gray300";
+
+export const formFieldDropdownTextClass =
+  "flex w-full cursor-pointer p-3 text-medium20 text-gray800";
+
+export const formFieldErrorClass = "relative text-medium14 text-red500";
+
+export const otpCellClass =
+  "flex h-16 w-16 items-center justify-center rounded-lg border border-gray300 bg-gray50 focus-within:bg-white";
+
+export const otpInputClass =
+  "w-full bg-transparent text-center text-semibold24 text-black";


### PR DESCRIPTION
## Summary
- `src/constant/formStyle.ts`를 추가해 인증 폼/필드에서 반복되던 레이아웃·입력·에러·OTP 스타일 클래스를 공통 상수로 분리했습니다.
- `src/components/RegisterInput.tsx`와 `src/app/(with-header)/signup/Register.tsx`에서 공통 스타일 상수를 사용하도록 변경해 입력 필드 스타일 중복을 줄였습니다.
- `src/app/(with-header)/login/page.tsx`와 `src/app/(with-header)/signup/page.tsx`의 인증 화면 레이아웃 클래스도 공통 상수로 통일했습니다.

## Verification
- changed files `lsp_diagnostics` clean
- `corepack yarn tsc --noEmit` 실행 시 기존 pre-existing 타입 오류(division/recent/userInfo의 Title/Sidebar props)로 실패