### PR TITLE
[DMWCOMM-8] document userInfo Sidebar prop 타입 불일치 수정

### DIFF
--- a/docs/plans/2026-02-14-dmwcomm-8-sidebar-props.md
+++ b/docs/plans/2026-02-14-dmwcomm-8-sidebar-props.md
@@ -1,0 +1,148 @@
+# DMWCOMM-8 Sidebar Props Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the `Sidebar` prop contract mismatch on document userInfo pages while preserving current document-page sidebar behavior.
+
+**Architecture:** Keep one `Sidebar` component and make its prop contract safe for both call sites. Interactive mode (document detail page) continues to use open-state sync and TOC scrolling. Fixed mode (userInfo page) must render without requiring interactive-only props.
+
+**Tech Stack:** Next.js App Router, React 18 client components, TypeScript strict mode, Tailwind CSS.
+
+---
+
+### Task 1: Reproduce and define exact baseline
+
+**Files:**
+
+- Verify: `src/components/Sidebar.tsx`
+- Verify: `src/app/(with-header)/document/[id]/page.tsx`
+- Verify: `src/app/(with-header)/document/[id]/userInfo/page.tsx`
+
+**Step 1: Capture typecheck baseline**
+
+Run:
+
+```bash
+corepack yarn tsc --noEmit
+```
+
+Expected:
+
+- Record all current errors.
+- Explicitly identify whether `Sidebar fixed` prop mismatch is present.
+
+**Step 2: Handle baseline mismatch decision**
+
+- If `Sidebar fixed` mismatch is present: continue with this plan.
+- If not present: identify the actual DMWCOMM-8-attributable failure first.
+- If no DMWCOMM-8-attributable failure exists: stop implementation and close ticket as already resolved.
+
+**Step 3: Confirm ticket scope boundary**
+
+The only in-scope fix is DMWCOMM-8 (`Sidebar` prop mismatch for userInfo usage). Do not include TitleProps or ESLint config fixes in this ticket.
+
+### Task 2: Implement minimal Sidebar contract fix
+
+**Files:**
+
+- Modify: `src/components/Sidebar.tsx`
+
+**Step 1: Update prop contract for dual usage**
+
+Make interactive-only props safe for fixed mode usage, and keep document page behavior intact.
+
+**Step 2: Guard interactive side effects**
+
+Guard open-state sync logic so fixed-mode rendering does not call undefined callbacks.
+
+**Step 3: Guard TOC rendering inputs**
+
+Use safe defaults for TOC list access so rendering works when TOC data is not supplied.
+
+**Step 4: Verify changed file compiles cleanly**
+
+Run:
+
+```bash
+corepack yarn tsc --noEmit
+```
+
+Expected:
+
+- `Sidebar fixed` prop mismatch is removed.
+- Any remaining errors are documented as pre-existing and out-of-scope.
+
+**Step 5: Commit**
+
+```bash
+git add src/components/Sidebar.tsx
+git commit -m "fix :: Sidebar fixed 모드 타입 계약 정리"
+```
+
+### Task 3: Run required verification workflow checkpoints
+
+**Files:**
+
+- Verify: `src/components/Sidebar.tsx`
+- Verify: `src/app/(with-header)/document/[id]/page.tsx`
+- Verify: `src/app/(with-header)/document/[id]/userInfo/page.tsx`
+
+**Step 1: 1st checkpoint (plan readiness)**
+
+Validate that each step in this plan is executable in this repo and has measurable output.
+
+**Step 2: 2nd checkpoint (post-implementation, pre-PR)**
+
+Run:
+
+```bash
+corepack yarn tsc --noEmit
+```
+
+Then run UI manual checks with dev server:
+
+```bash
+corepack yarn dev -p 3001
+```
+
+Required checks:
+
+- `/document/1` sidebar collapse/expand still works.
+- TOC click scroll still works.
+- Typecheck confirms no new DMWCOMM-8-attributable errors.
+
+Note:
+
+- `corepack yarn lint` is not a required gate in this ticket because ESLint config loading is tracked separately by DMWCOMM-10.
+
+**Step 3: Create PR**
+
+Title:
+
+```text
+[DMWCOMM-8] document userInfo Sidebar prop 타입 불일치 수정
+```
+
+PR body must include:
+
+- Root cause
+- Fix summary
+- Verification evidence (commands and observed results)
+
+**Step 4: 3rd checkpoint (PR-level gate)**
+
+Re-run typecheck and UI checklist against PR HEAD and merge only when no DMWCOMM-8-attributable blocker remains.
+
+### Task 4: Closeout
+
+**Step 1: Merge PR**
+
+```bash
+gh pr merge <PR_NUMBER> --merge
+```
+
+If `gh` authentication is unavailable, merge via GitHub web UI using the same gate criteria.
+
+**Step 2: Ticket update**
+
+Post verification summary to ticket and set status to done.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,8 +13,8 @@ interface ListProps {
 
 interface SidebarProps {
   fixed?: boolean;
-  setOpenSidebar: Dispatch<SetStateAction<boolean>>;
-  titleList: titleListProps[];
+  setOpenSidebar?: Dispatch<SetStateAction<boolean>>;
+  titleList?: titleListProps[];
 }
 
 interface titleListProps {
@@ -24,8 +24,11 @@ interface titleListProps {
 
 export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
   const [visible, setVisible] = useState<boolean>(true);
+  const tocList = titleList ?? [];
+  const isFixed = fixed ?? false;
 
   useEffect(() => {
+    if (!setOpenSidebar) return;
     setOpenSidebar(visible);
   }, [setOpenSidebar, visible]);
   const listArr = [
@@ -52,7 +55,7 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
 
   return (
     <>
-      {!visible && (
+      {!visible && !isFixed && (
         <button
           type="button"
           onClick={() => setVisible(true)}
@@ -68,7 +71,7 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
 
       <div
         style={{ height: `calc(100vh - 100px)` }}
-        className={`border z-20 fixed top-20 ${visible ? "left-0" : "-left-72"} transition-all bg-white rounded-r-2xl border-gray300 w-[280px] flex flex-col`}
+        className={`border z-20 fixed top-20 ${isFixed || visible ? "left-0" : "-left-72"} transition-all bg-white rounded-r-2xl border-gray300 w-[280px] flex flex-col`}
       >
         <div className="w-full flex p-4 items-center justify-between overflow">
           <div className="flex items-center">
@@ -80,15 +83,17 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
               이태영
             </div>
           </div>
-          <div
-            onClick={() => setVisible(!visible)}
-            className={`flex p-1 cursor-pointer transition-all absolute right-4 top-3.5`}
-          >
-            <Arrow_Double
-              className="text-gray400 transition-all"
-              direction={visible ? "left" : "right"}
-            />
-          </div>
+          {!isFixed && (
+            <div
+              onClick={() => setVisible(!visible)}
+              className={`flex p-1 cursor-pointer transition-all absolute right-4 top-3.5`}
+            >
+              <Arrow_Double
+                className="text-gray400 transition-all"
+                direction={visible ? "left" : "right"}
+              />
+            </div>
+          )}
         </div>
         <div className="w-full flex flex-col pl-5 pr-1 py-2 gap-8 h-full overflow-y-scroll">
           <SearchInput placeholder="문서 내 검색" />
@@ -100,26 +105,31 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
               ))}
             </div>
           </div>
-          <div className="w-full flex flex-col gap-2">
-            <p className="text-semibold14 text-gray600">목차</p>
-            <div className="flex w-full gap-1 flex-col">
-              {titleList.map(({ num, title }, index) => (
-                <List
-                  padding={num.split(".").length}
-                  indexList
-                  key={index}
-                  icon={<p className="text-semibold18 text-lime500">{num}</p>}
-                  text={title}
-                  onClick={() => {
-                    const targetId = `section-${num.replace(/\./g, "-")}`;
-                    document
-                      .getElementById(targetId)
-                      ?.scrollIntoView({ behavior: "smooth", block: "start" });
-                  }}
-                />
-              ))}
+          {tocList.length > 0 && (
+            <div className="w-full flex flex-col gap-2">
+              <p className="text-semibold14 text-gray600">목차</p>
+              <div className="flex w-full gap-1 flex-col">
+                {tocList.map(({ num, title }, index) => (
+                  <List
+                    padding={num.split(".").length}
+                    indexList
+                    key={index}
+                    icon={<p className="text-semibold18 text-lime500">{num}</p>}
+                    text={title}
+                    onClick={() => {
+                      const targetId = `section-${num.replace(/\./g, "-")}`;
+                      document
+                        .getElementById(targetId)
+                        ?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                        });
+                    }}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- add ticket implementation plan at `docs/plans/2026-02-14-dmwcomm-8-sidebar-props.md`
- update `Sidebar` prop contract to support fixed mode without requiring interactive props (`setOpenSidebar`, `titleList`)
- guard sidebar behavior by mode (fixed mode hides collapse controls and skips TOC rendering when list is absent)
- related ticket: #51

## Root Cause
- `src/app/(with-header)/document/[id]/userInfo/page.tsx` uses `<Sidebar fixed />`
- `src/components/Sidebar.tsx` previously required interactive-only props, causing TS2739 mismatch

## Verification (2nd Stage)
- `corepack yarn tsc --noEmit`
  - DMWCOMM-8 target error removed (`userInfo/page.tsx` Sidebar prop mismatch no longer appears)
  - remaining failures are pre-existing (`TitleProps.noShow` in division/recent)
- `corepack yarn lint`
  - pre-existing failure: `Failed to load config \"airbnb\"`
- UI verifier agent (Playwright) PASS
  - `/document/1`: collapse/expand and TOC scroll behavior pass
  - `/document/1/userInfo`: fixed sidebar renders without missing-prop regression

## Notes
- This PR is intentionally scoped to DMWCOMM-8 only.
- Follow-up pre-existing tickets:
  - #52 (`TitleProps noShow` mismatch)
  - #53 (`eslint airbnb` config load failure)