### PR TITLE
[DMWCOMM-9] TitleProps noShow 타입 계약 정리

### DIFF
--- a/docs/plans/2026-02-14-dmwcomm-9-title-props.md
+++ b/docs/plans/2026-02-14-dmwcomm-9-title-props.md
@@ -1,0 +1,104 @@
+# DMWCOMM-9 TitleProps noShow Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve TypeScript `TitleProps` contract mismatch caused by `noShow` usage in list/category pages without refactoring unrelated page UI.
+
+**Architecture:** Identify real `noShow` call sites first, then patch the exact `Title` component they import. Keep the fix contract-focused: add only required prop definitions and minimal behavior needed to keep existing rendering stable.
+
+**Tech Stack:** Next.js App Router, React 18 client components, TypeScript strict mode.
+
+---
+
+### Task 1: Capture DMWCOMM-9 baseline errors and call sites
+
+**Files:**
+
+- Verify: `src/app/**` files that pass `noShow` to `Title`
+- Verify: actual `Title` component file imported by those call sites
+
+**Step 1: Discover real `noShow` call sites**
+
+```bash
+grep -R "noShow" src/app --include "*.tsx"
+```
+
+Record each caller file and the import path it uses for `Title`.
+
+**Step 2: Run baseline typecheck**
+
+```bash
+yarn tsc --noEmit
+```
+
+Expected:
+
+- Confirm `TitleProps` errors are present on `noShow` (and related missing props if surfaced).
+
+**Step 3: Scope lock**
+
+Only fix `TitleProps` contract mismatch for this ticket. Do not include ESLint config or Sidebar changes.
+
+**Step 4: Baseline decision branch**
+
+- If `noShow`-related type errors are present: proceed.
+- If not present: stop and close DMWCOMM-9 as already resolved.
+
+### Task 2: Implement minimal Title contract fix on the actual shared file
+
+**Files:**
+
+- Modify: exact `Title` file used by `noShow` call sites (currently expected: `src/app/(with-header)/document/[id]/Title.tsx`)
+
+**Step 1: Add only missing optional props required by current call sites**
+
+At minimum, include `noShow?: boolean` if that is what typecheck reports.
+
+**Step 2: Apply minimal runtime behavior for noShow**
+
+Use `noShow` to conditionally hide the views block in `Title` while preserving current default behavior.
+
+**Step 3: Keep diff focused**
+
+Do not redesign typography/layout in this ticket; only adjust what is needed for contract compatibility.
+
+### Task 3: Verify and classify outcomes
+
+**Step 1: Run typecheck after fix**
+
+```bash
+yarn tsc --noEmit
+```
+
+Expected:
+
+- `TitleProps noShow` errors in discovered call-site paths are removed.
+- Any remaining failures are documented as pre-existing and out-of-scope.
+
+**Step 2: Run lint for blocker classification**
+
+```bash
+yarn lint
+```
+
+Expected:
+
+- Existing airbnb config load failure may remain (tracked separately by DMWCOMM-10).
+
+**Step 3: Changed-file diagnostics**
+
+Run diagnostics on modified files and ensure no new diagnostics.
+
+### Task 4: Verification workflow and closeout
+
+**Step 1: 1st checkpoint (plan readiness)**
+
+Validate this plan is executable and ticket-scoped.
+
+**Step 2: 2nd checkpoint (post-implementation, pre-PR)**
+
+Run local code verification and targeted UI sanity for pages using `Title`.
+
+**Step 3: PR and 3rd checkpoint (PR-level gate)**
+
+Create PR with evidence, re-run typecheck/lint classification and UI sanity checks on PR HEAD, and merge only when no DMWCOMM-9-attributable blocker remains (or explicit waiver).

--- a/src/app/(with-header)/document/[id]/Title.tsx
+++ b/src/app/(with-header)/document/[id]/Title.tsx
@@ -2,46 +2,51 @@ import React from "react";
 
 interface TitleProps {
   group?: string;
+  details?: string;
   title?: string;
   views?: number;
   noPadding?: boolean;
+  noShow?: boolean;
 }
 
 export const Title = ({
   title = "이태영",
   views = 210,
   noPadding,
+  noShow,
 }: TitleProps) => {
   return (
     <div
       className={`w-full flex justify-between items-center ${noPadding ? "py-8" : "py-12 px-12"} border-b border-gray200`}
     >
       <h1 className="text-bold36 text-black">{title}</h1>
-      <div className="flex items-center gap-2 text-gray500 text-medium14">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.99 12.482C6.47 13.957 9.06 16 12 16C14.94 16 17.53 13.957 19.01 12.482C19.4 12.094 19.6 11.898 19.72 11.517C19.81 11.244 19.81 10.756 19.72 10.483C19.6 10.102 19.4 9.906 19.01 9.518C17.53 8.043 14.94 6 12 6C9.06 6 6.47 8.043 4.99 9.518C4.6 9.907 4.4 10.101 4.28 10.483C4.19 10.756 4.19 11.244 4.28 11.517C4.4 11.899 4.6 12.093 4.99 12.482Z"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M10.33 11C10.33 11.92 11.08 12.667 12 12.667C12.92 12.667 13.67 11.92 13.67 11C13.67 10.08 12.92 9.333 12 9.333C11.08 9.333 10.33 10.08 10.33 11Z"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        <span>조회수: {views}</span>
-      </div>
+      {!noShow && (
+        <div className="flex items-center gap-2 text-gray500 text-medium14">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.99 12.482C6.47 13.957 9.06 16 12 16C14.94 16 17.53 13.957 19.01 12.482C19.4 12.094 19.6 11.898 19.72 11.517C19.81 11.244 19.81 10.756 19.72 10.483C19.6 10.102 19.4 9.906 19.01 9.518C17.53 8.043 14.94 6 12 6C9.06 6 6.47 8.043 4.99 9.518C4.6 9.907 4.4 10.101 4.28 10.483C4.19 10.756 4.19 11.244 4.28 11.517C4.4 11.899 4.6 12.093 4.99 12.482Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.33 11C10.33 11.92 11.08 12.667 12 12.667C12.92 12.667 13.67 11.92 13.67 11C13.67 10.08 12.92 9.333 12 9.333C11.08 9.333 10.33 10.08 10.33 11Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span>조회수: {views}</span>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add ticket implementation plan at `docs/plans/2026-02-14-dmwcomm-9-title-props.md`
- update `TitleProps` contract in `src/app/(with-header)/document/[id]/Title.tsx` to include `noShow` and caller-compatible optional fields
- apply minimal runtime behavior: hide views block when `noShow` is true
- related ticket: #52

## Root Cause
- multiple routes (`/division`, `/division/student`, `/recent`) pass `noShow` to `Title`
- shared `TitleProps` did not define `noShow`, causing TS2322 in those pages

## Verification (2nd Stage)
- `corepack yarn tsc --noEmit` ✅ pass
- `corepack yarn lint` ❌ pre-existing blocker: `Failed to load config "airbnb"` (tracked in #53)
- UI verifier (strict worktree runtime) ✅
  - `/division`, `/division/student`, `/recent`: title area hides `조회수` when noShow is used
  - `/document/1`: default behavior keeps `조회수` visible

## Scope
- This PR only addresses DMWCOMM-9 (`TitleProps noShow` contract + minimal display behavior).