### PR TITLE
[DMWCOMM-18] 모바일 가로 오버플로우 수정

### DIFF
--- a/docs/plans/2026-02-14-dmwcomm-18-mobile-overflow.md
+++ b/docs/plans/2026-02-14-dmwcomm-18-mobile-overflow.md
@@ -1,0 +1,116 @@
+# DMWCOMM-18 Mobile Overflow Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove mobile horizontal overflow on `/main`, `/team`, `/division`, `/recent`, and `/document/1` at `390x844` without changing desktop behavior.
+
+**Architecture:** Apply a minimal layout-only fix in three proven overflow points: shared header nav row, `/team` hero first section, and `/document/[id]` content padding. Keep interactions and desktop layout behavior intact while eliminating page-level horizontal overflow on mobile.
+
+**Tech Stack:** Next.js 14 App Router, React 18, Tailwind CSS, ESLint, TypeScript strict, Yarn via Corepack.
+
+---
+
+### Task 1: Toolchain preflight and baseline reproduction
+
+**Files:**
+
+- Modify: `src/components/Header.tsx`
+- Modify: `src/app/(with-header)/team/page.tsx`
+- Modify: `src/app/(with-header)/document/[id]/page.tsx`
+
+**Step 1:** Confirm repo-valid Yarn runtime.
+Run: `corepack enable`
+Run: `corepack prepare yarn@4 --activate`
+Run: `yarn --version`
+Expected: Yarn major version `4` is printed.
+
+**Step 2:** Install dependencies in fresh worktree.
+Run: `yarn install`
+Expected: Dependencies install without lockfile/toolchain errors.
+
+**Step 3:** Run baseline typecheck.
+Run: `yarn tsc --noEmit`
+Expected: Baseline type status recorded.
+
+**Step 4:** Start local server for visual baseline.
+Run: `yarn dev -p 3018`
+Expected: Local app starts on `http://localhost:3018`.
+
+**Step 5:** Reproduce baseline overflow on required routes.
+At viewport `390x844`, open `/main`, `/team`, `/division`, `/recent`, `/document/1` and run in browser console:
+
+```js
+Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) >
+  window.innerWidth;
+```
+
+Expected: At least one route returns `true` before fixes.
+
+### Task 2: Header mobile overflow fix (shared routes)
+
+**Files:**
+
+- Modify: `src/components/Header.tsx`
+
+**Step 1:** Make the first-row left cluster shrinkable.
+Update the row/left group classes so nav can shrink on mobile (`min-w-0` on the left cluster parent).
+
+**Step 2:** Constrain nav strip width on mobile.
+In the nav container (`src/components/Header.tsx`, nav strip block), replace the current `flex-none` behavior with shrinkable + internally scrollable behavior (`min-w-0 max-w-full overflow-x-auto`) and keep item chips non-shrinking.
+
+**Step 3:** Preserve interactions and desktop parity.
+Keep existing click handlers and dropdown behavior unchanged; do not remove nav items.
+
+### Task 3: Route-specific overflow fixes (`/team`, `/document/[id]`)
+
+**Files:**
+
+- Modify: `src/app/(with-header)/team/page.tsx`
+- Modify: `src/app/(with-header)/document/[id]/page.tsx`
+
+**Step 1:** Make `/team` hero first section responsive on mobile.
+In the first hero row (`src/app/(with-header)/team/page.tsx`, top section), switch to mobile-safe stacking (`flex-col` on small viewport, `lg:flex-row` on desktop) so logo/text no longer exceed viewport width.
+
+**Step 2:** Prevent `/document/[id]` mobile padding overflow.
+Change the root container padding logic so `pl-[300px]` applies only on large viewport when sidebar is open (e.g. `openSidebar ? "pl-6 lg:pl-[300px]" : "pl-6"`).
+
+**Step 3:** Keep desktop behavior unchanged.
+Desktop (`lg`) with expanded sidebar should preserve current visual spacing.
+
+### Task 4: 2nd local verification (implementation gate)
+
+**Files:**
+
+- Verify: `src/components/Header.tsx`
+- Verify: `src/app/(with-header)/team/page.tsx`
+- Verify: `src/app/(with-header)/document/[id]/page.tsx`
+
+**Step 1:** Re-run scoped lint.
+Run: `yarn lint -- --file src/components/Header.tsx --file "src/app/(with-header)/team/page.tsx" --file "src/app/(with-header)/document/[id]/page.tsx"`
+Expected: No new lint issues introduced by this ticket.
+Fallback: If repeated `--file` arguments are rejected, run `yarn lint` and classify failures as pre-existing vs ticket-introduced.
+
+**Step 2:** Re-run typecheck.
+Run: `yarn tsc --noEmit`
+Expected: No new TypeScript errors introduced.
+
+**Step 3:** Re-run build gate.
+Run: `yarn build`
+Expected: Build succeeds, or pre-existing failures are explicitly documented.
+
+**Step 4:** Verify mobile overflow behavior on required routes.
+At viewport `390x844`, verify `/main`, `/team`, `/division`, `/recent`, `/document/1` all satisfy:
+
+```js
+Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) <=
+  window.innerWidth;
+```
+
+**Step 5:** Verify desktop regression safety.
+At desktop viewport (`>=1420px`), confirm no layout regression in `/team` hero and `/document/1` main content width.
+
+**Step 6:** Confirm diff scope.
+Run: `git status --porcelain`
+Run: `git diff --name-only`
+Expected: Only allowlisted source files changed (no lockfile/config/generated file changes).
+Exception rule: If mobile overflow still reproduces on any required route after Tasks 2-3, expand to the minimum additional causal file(s) only, and record the reason for each added file in the PR description.

--- a/src/app/(with-header)/document/[id]/page.tsx
+++ b/src/app/(with-header)/document/[id]/page.tsx
@@ -32,7 +32,7 @@ function Document() {
   ];
   return (
     <div
-      className={`${openSidebar ? "pl-[300px]" : "pl-6"} transition-all pt-20 pb-20 pr-6 bg-gray100 justify-center flex w-full min-h-screen`}
+      className={`${openSidebar ? "pl-6 lg:pl-[300px]" : "pl-6"} transition-all pt-20 pb-20 pr-6 bg-gray100 justify-center flex w-full min-h-screen`}
     >
       <div className="flex w-full max-w-screen-xl flex-col overflow-hidden rounded-2xl border border-gray200 bg-white">
         <Title />

--- a/src/app/(with-header)/team/page.tsx
+++ b/src/app/(with-header)/team/page.tsx
@@ -60,7 +60,7 @@ export default function Team() {
   return (
     <div className="w-full flex justify-center flex-col">
       <div className="flex w-full max-w-screen-xl flex-col pt-16">
-        <div className="w-full px-12 py-24 gap-6 flex justify-between">
+        <div className="w-full px-6 lg:px-12 py-16 lg:py-24 gap-6 flex flex-col lg:flex-row lg:justify-between">
           <div className="flex flex-col gap-6 bg-white">
             <p className="text-bold40">
               대마위키를 만든
@@ -72,7 +72,7 @@ export default function Team() {
               위키 서비스, 대마위키를 기획하였습니다.
             </p>
           </div>
-          <div className="relative">
+          <div className="self-center lg:self-auto relative">
             <TeamLogo size={240} className="animate-fadeIn" />
             <div className="h-[500px] w-60 top-0 right-0 bg-gradient-to-t to-transparent from-white via-white absolute" />
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,8 +22,8 @@ export const Header = () => {
   return (
     <div className="w-full z-40 top-0 bg-white border-b border-gray200 flex flex-col">
       <div className="flex justify-center w-full px-6 bg-white border-b border-gray200">
-        <div className="py-3 w-full max-w-[1600px] justify-between items-center flex">
-          <div className="flex items-center gap-6">
+        <div className="py-3 w-full max-w-[1600px] justify-between items-center flex gap-3">
+          <div className="flex items-center gap-3 lg:gap-6 min-w-0">
             <div className="flex items-center gap-4">
               <div
                 onClick={() => router.push("/")}
@@ -41,15 +41,12 @@ export const Header = () => {
                 <Arrow className="text-gray400" size={16} direction="down" />
               </div>
             </div>
-            <div
-              className="flex items-center gap-2 flex-none
-          "
-            >
+            <div className="flex min-w-0 max-w-full items-center gap-2 overflow-x-auto sm:w-full">
               {navList.map(({ text, array, link }, index) => (
                 <div
                   onClick={() => router.push(`${link}`)}
                   key={index}
-                  className="flex relative items-center justify-center p-2 gap-0.5 group cursor-pointer transition-all"
+                  className="flex relative items-center justify-center p-2 gap-0.5 group cursor-pointer transition-all shrink-0"
                 >
                   <p className="text-semibold18 text-gray600 group-hover:text-lime500 transition-all">
                     {text}


### PR DESCRIPTION
## Summary
- 모바일(390x844)에서 페이지 가로 오버플로우를 유발하던 헤더 네비/팀 히어로/문서 패딩 레이아웃을 최소 변경으로 보정했습니다.
- `/main`, `/team`, `/division`, `/recent`, `/document/1`에서 `scrollWidth <= innerWidth` 기준으로 오버플로우가 제거되도록 조정했습니다.
- 구현 계획 문서와 1차 계획 검증 결과를 반영해 티켓 워크플로우를 유지했습니다.

## Verification (2nd local)
- `yarn lint -- --file src/components/Header.tsx --file "src/app/(with-header)/team/page.tsx" --file "src/app/(with-header)/document/[id]/page.tsx"` (기존 pre-existing lint 다수 확인, 신규 에러 없음)
- `yarn tsc --noEmit` (pass)
- `yarn build` (pre-existing lint로 실패)
- Local UI measurement (390x844):
  - `/main`: 390 / 390
  - `/team`: 374 / 390
  - `/division`: 374 / 390
  - `/recent`: 374 / 390
  - `/document/1`: 374 / 390

Closes #68