### PR TITLE
[DMWCOMM-28-29] Restore /main and /popular page rendering

### DIFF
--- a/docs/plans/2026-02-15-dmwcomm-28-29-main-popular-render.md
+++ b/docs/plans/2026-02-15-dmwcomm-28-29-main-popular-render.md
@@ -1,0 +1,124 @@
+# DMWCOMM-28-29 Main/Popular Rendering Recovery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore meaningful rendering for `/main` and `/popular` on `origin/dev` so both routes no longer show header-only blank bodies.
+
+**Architecture:** Keep the diff minimal and route-focused. Replace the current empty stub pages with the established implementations from the working baseline, then add only the missing wiki API/types/components required by `/popular`. Do not refactor unrelated UI domains in this ticket.
+
+**Tech Stack:** Next.js 14 App Router, React 18, TypeScript strict, React Query, Tailwind CSS.
+
+---
+
+### Task 1: Scope lock and dependency inventory
+
+**Files:**
+
+- Verify: `src/app/(with-header)/main/page.tsx`
+- Verify: `src/app/(with-header)/popular/page.tsx`
+- Verify: `src/apis/index.ts`
+- Verify: `src/components/index.ts`
+
+**Step 1:** Confirm branch and clean baseline.
+Run: `git status --short --branch`
+Expected: branch `dmwcomm-28-29-main-popular-render`, no unrelated edits.
+
+**Step 2:** Confirm current stubs.
+Run: `git show HEAD:"src/app/(with-header)/main/page.tsx" && git show HEAD:"src/app/(with-header)/popular/page.tsx"`
+Expected: both files are stub implementations (`return <></>`).
+
+**Step 3:** Lock missing dependencies required by `/popular` implementation.
+Run: `git grep -n "fetchPopularDocuments\|DocumentTable\|PageHeader\|PageSection" src`
+Expected: unresolved references in current branch before adding wiki modules.
+
+### Task 2: Restore `/main` route rendering
+
+**Files:**
+
+- Modify: `src/app/(with-header)/main/page.tsx`
+
+**Step 1:** Replace stub with full route content.
+Action: apply the established `Main` page implementation used in the current working baseline (hero + featured docs + people + guide sections + CTA flow).
+
+**Step 2:** Validate imports remain within existing modules.
+Action: ensure `Main` imports only available symbols (`Arrow_Short`, `Document`, `Quotes`, `next/navigation`, `useState`).
+
+**Step 3:** Keep route behavior aligned.
+Action: keep CTA links to `/division`, `/popular`, `/document/new`, `/division/student` as in baseline.
+
+### Task 3: Restore `/popular` route rendering and required wiki modules
+
+**Files:**
+
+- Modify: `src/app/(with-header)/popular/page.tsx`
+- Create: `src/interfaces/wiki.ts`
+- Create: `src/apis/wiki.ts`
+- Modify: `src/apis/index.ts`
+- Create: `src/components/wiki/CategoryBadge.tsx`
+- Create: `src/components/wiki/DocumentTable.tsx`
+- Create: `src/components/wiki/PageHeader.tsx`
+- Create: `src/components/wiki/PageSection.tsx`
+- Create: `src/components/wiki/index.ts`
+- Modify: `src/components/index.ts`
+
+**Step 1:** Replace `/popular` stub.
+Action: implement `Popular` route with React Query (`fetchPopularDocuments`) and loading/table states.
+
+**Step 2:** Add wiki type contracts.
+Action: add `WikiCategory`, `WikiDocumentSummary`, and related interfaces in `src/interfaces/wiki.ts`.
+
+**Step 3:** Add wiki API module.
+Action: add `src/apis/wiki.ts` with in-memory wiki dataset and exported helpers (`fetchPopularDocuments`, category labels, and supporting functions required by components).
+
+**Step 4:** Wire API barrel export.
+Action: update `src/apis/index.ts` to export `./wiki`.
+
+**Step 5:** Add wiki UI components.
+Action: add `CategoryBadge`, `DocumentTable`, `PageHeader`, `PageSection`, plus wiki barrel `src/components/wiki/index.ts`.
+
+**Step 6:** Wire component barrel export.
+Action: update `src/components/index.ts` to export `./wiki`.
+
+### Task 4: Verification gate
+
+**Files:**
+
+- Verify all modified/created files above
+
+**Step 1:** LSP diagnostics check.
+Run diagnostics on each changed TS/TSX file.
+Expected: no new diagnostics from changed files.
+
+**Step 2:** Typecheck.
+Run: `yarn tsc --noEmit`
+Expected: exit 0.
+
+**Step 3:** Scoped lint.
+Run:
+`yarn lint --file src/app/(with-header)/main/page.tsx --file src/app/(with-header)/popular/page.tsx --file src/apis/wiki.ts --file src/interfaces/wiki.ts --file src/components/wiki/CategoryBadge.tsx --file src/components/wiki/DocumentTable.tsx --file src/components/wiki/PageHeader.tsx --file src/components/wiki/PageSection.tsx --file src/components/wiki/index.ts --file src/apis/index.ts --file src/components/index.ts`
+Expected: if non-zero, classify pre-existing/global vs new route-scope issues.
+
+**Step 4:** Build check.
+Run: `yarn build`
+Expected: if non-zero, classify failure source and confirm whether caused by this diff.
+
+**Step 5:** Runtime smoke.
+Run: `yarn dev`
+Action:
+
+1. Verify `/main` renders non-empty body on desktop/mobile.
+2. Verify `/popular` renders header and loading/table area on desktop/mobile.
+3. Confirm no header-only blank body for these routes.
+
+### Task 5: Delivery preparation
+
+**Files:**
+
+- Verify changed-file list only contains issue-scope files
+
+**Step 1:** Scope confirmation.
+Run: `git diff --name-only`
+Expected: only route recovery + wiki dependency files + this plan doc.
+
+**Step 2:** Commit/PR prep (when requested).
+Action: split commits by concern (plan doc vs route/wiki implementation) and prepare PR targeting `dev` with `Closes #80` and `Closes #81`.

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,2 +1,3 @@
 export * from "./user";
 export * from "./mail";
+export * from "./wiki";

--- a/src/apis/wiki.ts
+++ b/src/apis/wiki.ts
@@ -1,0 +1,62 @@
+import { WikiCategory, WikiDocumentSummary } from "@/interfaces/wiki";
+
+const categoryLabelMap: Record<WikiCategory, string> = {
+  student: "학생",
+  teacher: "선생님",
+  accident: "사건/사고",
+  club: "동아리",
+};
+
+const popularDocuments: WikiDocumentSummary[] = [
+  {
+    id: "lee-taeyoung",
+    title: "이태영",
+    category: "student",
+    editor: "Daybreak",
+    updatedAt: "2024.08.01 07:50",
+    views: 210,
+  },
+  {
+    id: "kim-seungwon",
+    title: "김승원",
+    category: "student",
+    editor: "박지민",
+    updatedAt: "2026-02-07 09:30",
+    views: 184,
+  },
+  {
+    id: "kim-eojin",
+    title: "김어진",
+    category: "student",
+    editor: "김승원",
+    updatedAt: "2026-02-05 18:15",
+    views: 150,
+  },
+  {
+    id: "teacher-choi",
+    title: "최선생",
+    category: "teacher",
+    editor: "김어진",
+    updatedAt: "2026-02-04 11:40",
+    views: 132,
+  },
+  {
+    id: "accident-2025-hackathon",
+    title: "2025 해커톤 빌드 실패",
+    category: "accident",
+    editor: "박지민",
+    updatedAt: "2026-02-03 20:00",
+    views: 128,
+  },
+];
+
+const wait = <T>(value: T) =>
+  new Promise<T>(resolve => {
+    setTimeout(() => resolve(value), 120);
+  });
+
+export const wikiCategoryLabel = (category: WikiCategory) =>
+  categoryLabelMap[category];
+
+export const fetchPopularDocuments = async (): Promise<WikiDocumentSummary[]> =>
+  wait(popularDocuments);

--- a/src/app/(with-header)/main/page.tsx
+++ b/src/app/(with-header)/main/page.tsx
@@ -1,8 +1,384 @@
 "use client";
-import React from "react";
+
+import { Arrow_Short as ArrowShort, Document, Quotes } from "@/assets";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const featuredDocs = [
+  {
+    id: "doc-1",
+    title: "새벽에 기숙사 탈출",
+    description:
+      "어두운 새벽, 조용한 기숙사에서 벗어나는 그 순간의 긴장감은 이 미스터리 사건 같았습니다. 조심스럽게 발걸음을 내딛던 사람들의 흔적이 남아 있었더라고요.",
+    category: "사건/사고",
+    editor: "이서영",
+    views: 210,
+    hot: true,
+  },
+  {
+    id: "doc-2",
+    title: "합발림 미수 사건",
+    description:
+      "평범해 보이는 사건은 사회에 큰 충격을 주는 범죄 사건 중 하나입니다. 범인은 피해자에게 혐을 휘두르려 했지만, 운 좋게도 피해자는 사망하지 않았습니다. 이 사건으로 인해 사회는 범죄 예방에 대한 논의를 촉발하고, 보다 강력한 법 집행과 사회 안전을 강화하는 노력이 필요하다는 인식이 높아졌습니다.",
+    category: "사건/사고",
+    editor: "유지우",
+    views: 198,
+  },
+  {
+    id: "doc-3",
+    title: "김승원 공략법 v0.3",
+    description:
+      "김승원을 본인이 말하길 자신을 수도권이라고 하지만, 사실상 브라만 급으로 높은 완성도의 얼굴을 가지고 있다. 그렇기에 김승원은 필연적으로 인기가 많을 수밖에 없고, 이 글에서는 그 김승원을 공략하기 위한 방안을 모색해보고자 한다. 1. 가장 확실한 방법은, 일본과 관련된 문화를 핑계로 접근하는 것이다.",
+    category: "정보/유용한 정보/인물",
+    editor: "이태영",
+    views: 173,
+  },
+];
+
+const people = [
+  {
+    name: "이태영",
+    description:
+      "저는 프로그래밍된 세계에서 벗어난 사람을 담당하는 작은 햄스터입니다. 디테일하면서도 느긋한 편입니다.",
+    highlight: false,
+  },
+  {
+    name: "고은총",
+    description: "2학년 3반의 보안쟁이.",
+    highlight: false,
+  },
+  {
+    name: "김대운",
+    description: "아이아이를 하고 있고 뭔가 이상한 이미지시고미가 이동돈 돈왕",
+    highlight: false,
+  },
+  {
+    name: "장지성",
+    description: "재밌는 공학부!",
+    highlight: false,
+  },
+  {
+    name: "은비차",
+    description:
+      "간격감이 신선하고 있는 보안쟁이. 경력으로도 입이맛깔잡이입니다.",
+    highlight: false,
+  },
+  {
+    name: "조승우",
+    description: "포토 그래퍼",
+    highlight: true,
+  },
+  {
+    name: "조태근",
+    description:
+      "한기코딩과 프론트엔드 쪽의 인재. 긴자치이지만 자부 이상한 데를 지원하시는",
+    highlight: false,
+  },
+  {
+    name: "유지우",
+    description: "찐트 롤테이터",
+    highlight: false,
+  },
+  {
+    name: "이지호",
+    description:
+      "비트코인 디자이너 이재혁입니다. 베트발 및 체리링기롤 연구하고 있습니다.",
+    highlight: false,
+  },
+  {
+    name: "이재영",
+    description: "080808080808080808",
+    highlight: false,
+  },
+];
+
+const guides = [
+  {
+    title: "문서를 생성하세요.",
+    description:
+      "분류에 들어가 문서 추가 버튼을 눌러 문서를 생성하세요. 워드프로세서를 통해 문서를 작성하고 서식을 적용해 코드 또는 마크다운 형식으로 문서를 작성할 수 있습니다.",
+  },
+  {
+    title: "문서를 수정하세요.",
+    description:
+      "기존 문서에서 수정 버튼을 눌러 내용을 편집할 수 있습니다. 변경 내역은 문서 기록에 자동으로 남습니다.",
+  },
+  {
+    title: "에피고를 활용하세요.",
+    description:
+      "자주 쓰는 템플릿과 링크를 저장해 빠르게 문서를 작성하세요. 팀 내 문서 품질을 일정하게 유지할 수 있습니다.",
+  },
+];
+
+const guideTabLabels = ["문서 생성", "문서 수정", "어쩌고"];
 
 function Main() {
-  return <></>;
+  const router = useRouter();
+  const [guideIndex, setGuideIndex] = useState(0);
+
+  return (
+    <div className="flex w-full justify-center bg-gray100 pb-28">
+      <div className="flex w-full max-w-6xl flex-col items-center px-4 md:px-4 sm:px-4">
+        <section className="flex w-full flex-col items-center gap-8 pb-28 pt-20 text-center">
+          <button
+            type="button"
+            onClick={() => router.push("/document/new")}
+            className="flex items-center gap-1 rounded-full bg-gray100 px-4 py-2 text-semibold14 text-gray600 transition-all hover:bg-gray200"
+          >
+            내 문서 만들기
+            <ArrowShort size={16} className="text-gray500" direction="right" />
+          </button>
+
+          <div className="flex flex-col items-center gap-5">
+            <h1 className="text-bold48 text-gray900 sm:text-bold36">
+              우리의 학교생활 이야기
+              <br />
+              <span className="text-lime500">대마위키에서</span>
+            </h1>
+            <p className="text-medium16 text-gray500">
+              학생들의 정보와 학교에서 일어난 사건을 기록하는 곳.
+              <br />
+              대마위키에서 함께 정보를 공유하고 학교 생활을 기록해보세요.
+              <br />
+              나만 몰랐던 우리 학교 이야기.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => router.push("/division")}
+              className="rounded-md bg-lime500 px-4 py-2 text-semibold16 text-white transition-all hover:bg-lime600"
+            >
+              시작하기
+            </button>
+            <button
+              type="button"
+              onClick={() => router.push("/popular")}
+              className="flex items-center gap-1 rounded-md border border-gray200 bg-white px-4 py-2 text-semibold16 text-gray600 transition-all hover:bg-gray50"
+            >
+              <Document size={15} className="text-gray500" />
+              랜덤 문서
+            </button>
+          </div>
+        </section>
+
+        <section className="flex w-full flex-col items-center gap-8 py-24">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <h2 className="text-bold48 text-gray900 sm:text-bold36">
+              인기있는 문서들
+            </h2>
+            <p className="text-medium16 text-gray500">
+              다양한 주제와 깊이 있는 정보로 학생들의 호기심을 자극하는 인기있는
+              문서들이 모여있습니다.
+            </p>
+          </div>
+
+          <div className="flex w-full justify-center gap-4 md:flex-col md:items-center sm:flex-col sm:items-center">
+            {featuredDocs.map((doc, index) => (
+              <article
+                key={doc.id}
+                className="flex min-h-96 w-96 flex-col rounded-2xl border border-gray200 bg-white p-5 shadow-sm md:w-full sm:w-full"
+              >
+                <div className="flex items-center justify-between pb-5">
+                  <div className="rounded-lg bg-gray100 p-2 text-gray300">
+                    <Quotes size={18} />
+                  </div>
+                  {index === 0 && doc.hot && (
+                    <span className="rounded-full bg-lime100 px-2 py-1 text-medium12 text-lime700">
+                      HOT
+                    </span>
+                  )}
+                </div>
+
+                <p className="text-semibold20 text-gray900">{doc.title}</p>
+                <p className="pt-3 text-medium14 text-gray500">
+                  {doc.description}
+                </p>
+
+                <div className="mt-auto flex items-center justify-between pt-6 text-medium12 text-gray500">
+                  <div className="flex items-center gap-2">
+                    <span>{doc.category}</span>
+                    <span className="text-lime600">/</span>
+                    <span className="text-lime600">{doc.editor}</span>
+                  </div>
+                  <div className="flex items-center gap-1 text-gray400">
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M4.99 12.482C6.47 13.957 9.06 16 12 16C14.94 16 17.53 13.957 19.01 12.482C19.4 12.094 19.6 11.898 19.72 11.517C19.81 11.244 19.81 10.756 19.72 10.483C19.6 10.102 19.4 9.906 19.01 9.518C17.53 8.043 14.94 6 12 6C9.06 6 6.47 8.043 4.99 9.518C4.6 9.907 4.4 10.101 4.28 10.483C4.19 10.756 4.19 11.244 4.28 11.517C4.4 11.899 4.6 12.093 4.99 12.482Z"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M10.33 11C10.33 11.92 11.08 12.667 12 12.667C12.92 12.667 13.67 11.92 13.67 11C13.67 10.08 12.92 9.333 12 9.333C11.08 9.333 10.33 10.08 10.33 11Z"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    {doc.views}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => router.push("/popular")}
+            className="flex items-center gap-1 rounded-full border border-gray200 bg-white px-4 py-2 text-semibold14 text-gray600 transition-all hover:bg-gray50"
+          >
+            더보기
+            <ArrowShort size={16} className="text-gray500" direction="right" />
+          </button>
+        </section>
+
+        <section className="flex w-full flex-col items-center gap-8 py-24">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <h2 className="text-bold40 text-gray900 sm:text-bold32">
+              인기있는 사람들
+            </h2>
+            <p className="text-medium16 text-gray500">
+              대마고에서는 주로 이상한 애들이 인기가 많습니다.
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="rounded-md border border-gray200 bg-white px-3 py-1 text-semibold14 text-gray600"
+              >
+                분야별 인간 보기
+              </button>
+              <button
+                type="button"
+                className="rounded-md bg-gray200 px-3 py-1 text-semibold14 text-gray600"
+              >
+                선생님
+              </button>
+            </div>
+          </div>
+
+          <div className="grid w-full grid-cols-4 gap-2 md:grid-cols-2 sm:grid-cols-1">
+            {people.map(person => (
+              <article
+                key={person.name}
+                className={`min-h-32 rounded-xl border p-4 ${
+                  person.highlight
+                    ? "border-lime300 bg-lime50"
+                    : "border-gray200 bg-white"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray200 text-medium12 text-gray600">
+                      {person.name.slice(0, 1)}
+                    </div>
+                    <p className="text-semibold16 text-gray900">
+                      {person.name}
+                    </p>
+                  </div>
+                  <span className="text-medium12 text-lime600">작성</span>
+                </div>
+                <p className="pt-3 text-medium14 text-gray500">
+                  {person.description}
+                </p>
+              </article>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => router.push("/division/student")}
+            className="flex items-center gap-1 rounded-full border border-gray200 bg-white px-4 py-2 text-semibold14 text-gray600 transition-all hover:bg-gray50"
+          >
+            더보기
+            <ArrowShort size={16} className="text-gray500" direction="right" />
+          </button>
+        </section>
+
+        <section className="flex w-full flex-col gap-8 py-24">
+          <div className="text-left">
+            <p className="text-semibold16 text-lime500">첫 사용자들을 위한</p>
+            <h2 className="pt-2 text-bold36 text-gray900 sm:text-bold32">
+              대마위키 사용법
+            </h2>
+            <p className="pt-3 text-medium16 text-gray500">
+              스트레스를 해소하고 친구를 유명하게 만들어주고 싶나요?
+              <br />
+              키보드를 잡으세요.
+            </p>
+          </div>
+
+          <div className="flex border-b border-gray200">
+            {guides.map((guide, index) => (
+              <button
+                key={guide.title}
+                type="button"
+                onClick={() => setGuideIndex(index)}
+                className={`pb-3 pr-6 text-semibold16 transition-all ${
+                  guideIndex === index
+                    ? "border-b-2 border-lime500 text-gray900"
+                    : "text-gray500"
+                }`}
+              >
+                {guideTabLabels[index]}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-8 md:grid-cols-1">
+            <div className="flex flex-col gap-5">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-lime100 text-semibold20 text-lime600">
+                1
+              </div>
+              <h3 className="text-bold32 text-gray900">
+                {guides[guideIndex].title}
+              </h3>
+              <p className="text-medium16 text-gray500">
+                {guides[guideIndex].description}
+              </p>
+              <button
+                type="button"
+                onClick={() => router.push("/document/new")}
+                className="flex w-fit items-center gap-1 rounded-full border border-gray200 bg-white px-4 py-2 text-semibold14 text-gray600 transition-all hover:bg-gray50"
+              >
+                직접 해보기
+                <ArrowShort
+                  size={16}
+                  className="text-gray500"
+                  direction="right"
+                />
+              </button>
+            </div>
+            <div className="min-h-56 rounded-2xl bg-gray200" />
+          </div>
+        </section>
+
+        <section className="flex flex-col items-center gap-5 py-20 text-center sm:py-16">
+          <h2 className="text-bold40 text-gray900 sm:text-bold32">
+            대마위키 문서
+            <br />
+            구경가기
+          </h2>
+          <button
+            type="button"
+            onClick={() => router.push("/division")}
+            className="rounded-md bg-lime500 px-4 py-2 text-semibold16 text-white transition-all hover:bg-lime600"
+          >
+            시작하기
+          </button>
+        </section>
+      </div>
+    </div>
+  );
 }
 
 export default Main;

--- a/src/app/(with-header)/popular/page.tsx
+++ b/src/app/(with-header)/popular/page.tsx
@@ -1,8 +1,36 @@
 "use client";
-import React from "react";
+
+import { fetchPopularDocuments } from "@/apis";
+import { DocumentTable, PageHeader, PageSection } from "@/components/wiki";
+import { useQuery } from "@tanstack/react-query";
 
 function Popular() {
-  return <></>;
+  const { data, isLoading } = useQuery({
+    queryKey: ["popular-documents"],
+    queryFn: fetchPopularDocuments,
+  });
+
+  return (
+    <div className="flex w-full justify-center pb-12">
+      <div className="flex w-full max-w-screen-xl flex-col gap-10 px-12 pt-16">
+        <PageHeader
+          title="인기 문서"
+          subtitle="대마위키"
+          description="조회수가 높은 문서를 확인하세요"
+        />
+
+        <PageSection title="인기 순위">
+          {isLoading ? (
+            <div className="rounded-2xl border border-gray200 bg-white px-6 py-12 text-center text-medium16 text-gray500">
+              문서를 불러오는 중입니다...
+            </div>
+          ) : (
+            <DocumentTable rows={data ?? []} />
+          )}
+        </PageSection>
+      </div>
+    </div>
+  );
 }
 
 export default Popular;

--- a/src/components/wiki/CategoryBadge.tsx
+++ b/src/components/wiki/CategoryBadge.tsx
@@ -1,0 +1,16 @@
+import { wikiCategoryLabel } from "@/apis/wiki";
+import { WikiCategory } from "@/interfaces/wiki";
+
+interface CategoryBadgeProps {
+  category: WikiCategory;
+}
+
+function CategoryBadge({ category }: CategoryBadgeProps) {
+  return (
+    <span className="rounded-full bg-lime50 px-3 py-1 text-semibold14 text-lime500">
+      {wikiCategoryLabel(category)}
+    </span>
+  );
+}
+
+export default CategoryBadge;

--- a/src/components/wiki/DocumentTable.tsx
+++ b/src/components/wiki/DocumentTable.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { WikiDocumentSummary } from "@/interfaces/wiki";
+import CategoryBadge from "./CategoryBadge";
+
+interface DocumentTableProps {
+  rows: WikiDocumentSummary[];
+  emptyText?: string;
+}
+
+function DocumentTable({
+  rows,
+  emptyText = "표시할 문서가 없습니다.",
+}: DocumentTableProps) {
+  const router = useRouter();
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-gray200 bg-white">
+      <div className="grid grid-cols-5 gap-4 bg-gray50 px-5 py-4 text-medium16 text-gray600 md:grid-cols-3 sm:grid-cols-2">
+        <p>문서</p>
+        <p className="md:hidden sm:hidden">분류</p>
+        <p>편집자</p>
+        <p className="sm:hidden">최근 수정</p>
+        <p className="text-right md:text-left">조회수</p>
+      </div>
+
+      {rows.length === 0 && (
+        <div className="px-5 py-12 text-center text-medium16 text-gray500">
+          {emptyText}
+        </div>
+      )}
+
+      {rows.map(row => (
+        <button
+          key={row.id}
+          type="button"
+          onClick={() => router.push(`/document/${row.id}`)}
+          className="grid w-full grid-cols-5 gap-4 border-t border-gray100 px-5 py-4 text-left transition-all hover:bg-gray50 md:grid-cols-3 sm:grid-cols-2"
+        >
+          <p className="text-medium16 text-black">{row.title}</p>
+          <div className="md:hidden sm:hidden">
+            <CategoryBadge category={row.category} />
+          </div>
+          <p className="text-medium16 text-gray600">{row.editor}</p>
+          <p className="text-medium16 text-gray500 sm:hidden">
+            {row.updatedAt}
+          </p>
+          <p className="text-right text-medium16 text-gray500 md:text-left">
+            {row.views}
+          </p>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+DocumentTable.defaultProps = {
+  emptyText: "표시할 문서가 없습니다.",
+};
+
+export default DocumentTable;

--- a/src/components/wiki/PageHeader.tsx
+++ b/src/components/wiki/PageHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+function PageHeader({ title, subtitle, description, action }: PageHeaderProps) {
+  return (
+    <div className="flex w-full items-end justify-between gap-6 sm:flex-col sm:items-start">
+      <div className="flex flex-col gap-3">
+        {subtitle && <p className="text-semibold18 text-lime500">{subtitle}</p>}
+        <h1 className="text-bold40 text-black">{title}</h1>
+        {description && (
+          <p className="text-medium18 text-gray500">{description}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+PageHeader.defaultProps = {
+  subtitle: undefined,
+  description: undefined,
+  action: undefined,
+};
+
+export default PageHeader;

--- a/src/components/wiki/PageSection.tsx
+++ b/src/components/wiki/PageSection.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface PageSectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+function PageSection({ title, description, children }: PageSectionProps) {
+  return (
+    <section className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-semibold24 text-black">{title}</h2>
+        {description && (
+          <p className="text-medium16 text-gray500">{description}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+PageSection.defaultProps = {
+  description: undefined,
+};
+
+export default PageSection;

--- a/src/components/wiki/index.ts
+++ b/src/components/wiki/index.ts
@@ -1,0 +1,4 @@
+export { default as CategoryBadge } from "./CategoryBadge";
+export { default as DocumentTable } from "./DocumentTable";
+export { default as PageHeader } from "./PageHeader";
+export { default as PageSection } from "./PageSection";

--- a/src/interfaces/wiki.ts
+++ b/src/interfaces/wiki.ts
@@ -1,0 +1,10 @@
+export type WikiCategory = "student" | "teacher" | "accident" | "club";
+
+export interface WikiDocumentSummary {
+  id: string;
+  title: string;
+  category: WikiCategory;
+  editor: string;
+  updatedAt: string;
+  views: number;
+}


### PR DESCRIPTION
## Summary
- Restore full rendering on `/main` by replacing the placeholder return with the FO-5-1-aligned section layout.
- Restore `/popular` rendering with React Query data flow and a complete wiki component surface (`PageHeader`, `PageSection`, `CategoryBadge`, `DocumentTable`).
- Add missing wiki domain modules on `dev` (`src/apis/wiki.ts`, `src/interfaces/wiki.ts`) and wire exports for page integration.

## Validation
- `yarn tsc --noEmit` (pass)
- scoped `next lint` on changed files (pass)
- Playwright smoke: `/main`, `/popular` at desktop/mobile (pass)
- `yarn build` currently blocked by pre-existing repo-wide lint issues outside this diff

Closes #80
Closes #81