### PR TITLE
[DMWCOMM-30] Hide React Query Devtools in product UI

### DIFF
--- a/src/app/ReactQueryProvider.tsx
+++ b/src/app/ReactQueryProvider.tsx
@@ -1,20 +1,12 @@
 "use client";
 
-import {
-  QueryClient,
-  QueryClientProvider,
-  hydrate,
-} from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, useState } from "react";
 
 export default function ReactQueryProvider({ children }: PropsWithChildren) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Remove React Query Devtools mount from production UI provider flow.
- Prevent floating devtools trigger from leaking into user-facing routes.

## Validation
- `yarn tsc --noEmit`
- `yarn lint --file src/app/ReactQueryProvider.tsx`

Closes #82