### PR TITLE
[DMWCOMM-33-34] Improve userInfo mobile readability and edit layout

### DIFF
--- a/src/app/(with-header)/document/[id]/userInfo/page.tsx
+++ b/src/app/(with-header)/document/[id]/userInfo/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Sidebar } from "@/components";
-import { Title } from "../Title";
 import { User, Calendar } from "@/assets";
-import EditHistory from "./EditHistory";
 import { useState } from "react";
+import { Title } from "../Title";
+import EditHistory from "./EditHistory";
 
 interface MockDataType {
   index: string;
@@ -69,40 +69,46 @@ export default function UserInfo() {
   };
 
   return (
-    <div className="flex justify-center pt-16">
+    <div className="flex justify-center pt-16 sm:pt-10">
       <Sidebar fixed />
       <div className="flex flex-grow max-w-screen-xl flex-col">
         <Title />
-        <div className="flex flex-col py-6 px-12 gap-20">
-          <div className="flex gap-20">
+        <div className="flex flex-col px-12 py-6 gap-20 sm:px-4 sm:gap-10">
+          <div className="flex gap-20 sm:flex-col sm:gap-8">
             <div className="flex flex-col gap-5">
               <span className="text-medium20">문서 정보</span>
               <div className="flex flex-col gap-4">
-                <div className="flex gap-5 items-center">
-                  <div className="w-[100px] text-medium18">생성자</div>
+                <div className="flex items-center gap-5 sm:flex-col sm:items-start sm:gap-2">
+                  <div className="w-[100px] text-medium18 sm:w-auto">
+                    생성자
+                  </div>
                   <div className="flex px-3 py-2 gap-2 border-[1px] border-gray200 rounded-lg">
                     <User className="text-gray500" />
                     <span>이태영</span>
                   </div>
                 </div>
-                <div className="flex gap-5 items-center">
-                  <div className="w-[100px] text-medium18">문서 생성일</div>
+                <div className="flex items-center gap-5 sm:flex-col sm:items-start sm:gap-2">
+                  <div className="w-[100px] text-medium18 sm:w-auto">
+                    문서 생성일
+                  </div>
                   <div className="flex px-3 py-2 gap-2 border-[1px] border-gray200 rounded-lg">
                     <Calendar className="text-gray500" />
                     <span className="whitespace-nowrap">2024.09.12 10:39</span>
                   </div>
                 </div>
-                <div className="flex gap-5 items-center">
-                  <div className="w-[100px] text-medium18">최근 수정일</div>
+                <div className="flex items-center gap-5 sm:flex-col sm:items-start sm:gap-2">
+                  <div className="w-[100px] text-medium18 sm:w-auto">
+                    최근 수정일
+                  </div>
                   <div className="flex px-3 py-2 gap-2 border-[1px] border-gray200 rounded-lg">
                     <Calendar className="text-gray500" />
                     <span className="whitespace-nowrap">2024.08.03 23:20</span>
                   </div>
                 </div>
-                <div className="flex gap-5 items-center">
-                  <div className="w-[100px] text-medium18">분류</div>
+                <div className="flex items-center gap-5 sm:flex-col sm:items-start sm:gap-2">
+                  <div className="w-[100px] text-medium18 sm:w-auto">분류</div>
                   <div className="flex px-3 py-[6px] gap-[10px] rounded-full bg-lime100 items-center">
-                    <div className="w-[10px] h-[10px] rounded-full bg-lime400"></div>
+                    <div className="w-[10px] h-[10px] rounded-full bg-lime400" />
                     <span className="whitespace-nowrap">학생</span>
                   </div>
                 </div>
@@ -110,7 +116,7 @@ export default function UserInfo() {
             </div>
             <div className="flex flex-col gap-5 flex-grow">
               <span className="text-medium20">기여자</span>
-              <div className="flex gap-4 p-4 border-[1px] border-gray200 rounded-xl flex-wrap flex-shrink-0 w-full">
+              <div className="flex w-full flex-shrink-0 flex-wrap gap-4 border-[1px] border-gray200 rounded-xl p-4 sm:gap-3">
                 <span>박지민</span>
                 <span>박지민</span>
                 <span>박지민</span>
@@ -129,19 +135,19 @@ export default function UserInfo() {
           </div>
           <div className="flex flex-col gap-5">
             <span className="text-medium20">문서 수정 내역</span>
-            <div className="py-4 flex flex-col border-[1px] border-gray200 rounded-xl">
+            <div className="py-4 flex flex-col border-[1px] border-gray200 rounded-xl overflow-x-auto">
               <div className="px-4">
-                <div className="bg-gray100 p-3 flex text-gray500 rounded-md h-10 items-center">
+                <div className="bg-gray100 p-3 flex text-gray500 rounded-md h-10 items-center min-w-[540px] sm:min-w-[480px]">
                   <div className="flex-grow">목차</div>
                   <div className="flex-grow max-w-[240px]">이름</div>
                   <div className="flex-grow max-w-[240px]">날짜</div>
-                  <div className="w-6"></div>
+                  <div className="w-6" />
                 </div>
               </div>
               {MockData.map(
                 ({ index, title, editor, editDate, editHistory }, key) => (
                   <EditHistory
-                    key={key}
+                    key={`${editDate}-${title}`}
                     index={index}
                     title={title}
                     editor={editor}
@@ -157,7 +163,7 @@ export default function UserInfo() {
           </div>
         </div>
       </div>
-      <section className="max-w-screen-xl"></section>
+      <section className="max-w-screen-xl" />
     </div>
   );
 }

--- a/src/app/(without-header)/document/[id]/edit/page.tsx
+++ b/src/app/(without-header)/document/[id]/edit/page.tsx
@@ -1,21 +1,80 @@
 import { Close, Document } from "@/assets";
-import { Button } from "@/components";
 
-const Edit = () => {
+export default function Edit() {
   return (
-    <div className="flex flex-col w-full">
-      <div className="flex justify-between">
-        <Close className="text-gray600 w-6" />
-        <Button style="primary2" text="저장">
-          <Document />
-        </Button>
-      </div>
-      <div className="flex">
-        <div className="flex">사이드바</div>
-        <textarea></textarea>
+    <div className="flex min-h-screen w-full flex-col bg-gray50">
+      <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6 px-6 py-6 sm:px-4 sm:py-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray200 bg-white px-4 py-3">
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-md border border-gray200 bg-white px-3 py-2 text-medium16 text-gray700 hover:bg-gray50"
+          >
+            <Close className="w-5 text-gray600" />
+            닫기
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg bg-lime500 px-4 py-3 text-semibold16 text-white hover:bg-lime600"
+          >
+            <Document className="text-white" />
+            저장
+          </button>
+        </div>
+
+        <div className="grid grid-cols-[280px_1fr] gap-6 sm:grid-cols-1">
+          <aside className="flex h-fit flex-col gap-4 rounded-xl border border-gray200 bg-white p-4">
+            <div className="flex flex-col gap-1">
+              <p className="text-semibold16 text-black">문서 메타</p>
+              <p className="text-medium14 text-gray500">
+                작성 정보를 먼저 정리하세요.
+              </p>
+            </div>
+            <label htmlFor="category" className="flex flex-col gap-2">
+              <span className="text-medium14 text-gray600">분류</span>
+              <input
+                id="category"
+                className="rounded-lg border border-gray200 px-3 py-2 text-medium16 text-black placeholder:text-gray400"
+                placeholder="예: 학생"
+              />
+            </label>
+            <label htmlFor="tags" className="flex flex-col gap-2">
+              <span className="text-medium14 text-gray600">태그</span>
+              <input
+                id="tags"
+                className="rounded-lg border border-gray200 px-3 py-2 text-medium16 text-black placeholder:text-gray400"
+                placeholder="예: 대마고, 동아리"
+              />
+            </label>
+          </aside>
+
+          <section className="flex min-h-[520px] flex-col gap-4 rounded-xl border border-gray200 bg-white p-4 sm:min-h-[420px]">
+            <label htmlFor="title" className="flex flex-col gap-2">
+              <span className="text-medium14 text-gray600">문서 제목</span>
+              <input
+                id="title"
+                className="rounded-lg border border-gray200 px-3 py-2 text-medium18 text-black placeholder:text-gray400"
+                placeholder="문서 제목을 입력하세요"
+              />
+            </label>
+            <label htmlFor="summary" className="flex flex-col gap-2">
+              <span className="text-medium14 text-gray600">요약</span>
+              <input
+                id="summary"
+                className="rounded-lg border border-gray200 px-3 py-2 text-medium16 text-black placeholder:text-gray400"
+                placeholder="이 문서를 한 줄로 설명하세요"
+              />
+            </label>
+            <label htmlFor="content" className="flex h-full flex-col gap-2">
+              <span className="text-medium14 text-gray600">본문</span>
+              <textarea
+                id="content"
+                className="h-full min-h-[320px] rounded-lg border border-gray200 px-3 py-3 text-medium16 text-black placeholder:text-gray400"
+                placeholder="문서 내용을 입력하세요"
+              />
+            </label>
+          </section>
+        </div>
       </div>
     </div>
   );
-};
-
-export default Edit;
+}


### PR DESCRIPTION
## Summary
- Improve `/document/[id]/userInfo` mobile readability with stacked metadata rows and safer horizontal behavior.
- Replace near-empty `/document/[id]/edit` layout with structured edit shell (actions, meta pane, content pane).

## Validation
- `yarn tsc --noEmit`
- `yarn lint --file src/app/(with-header)/document/[id]/userInfo/page.tsx --file src/app/(without-header)/document/[id]/edit/page.tsx`

Closes #84
Closes #85