### PR TITLE
[DMWCOMM-35-40-23] Improve division/team affordance and route gutter rhythm

### DIFF
--- a/src/app/(with-header)/division/Card.tsx
+++ b/src/app/(with-header)/division/Card.tsx
@@ -1,4 +1,10 @@
-import { Arrow_Short, Book, Notebook, User, Warn } from "@/assets";
+import {
+  Arrow_Short as ArrowShort,
+  Book,
+  Notebook,
+  User,
+  Warn,
+} from "@/assets";
 
 interface CardProps {
   longWidth?: boolean;
@@ -6,7 +12,7 @@ interface CardProps {
   onClick?: () => void;
 }
 
-export const Card = ({ longWidth, type, onClick }: CardProps) => {
+export default function Card({ longWidth, type, onClick }: CardProps) {
   const cardIcon = {
     student: {
       icon: <User />,
@@ -30,23 +36,29 @@ export const Card = ({ longWidth, type, onClick }: CardProps) => {
     },
   };
   return (
-    <div
+    <button
+      type="button"
       onClick={onClick}
-      className={`w-full group hover:shadow-lg ${longWidth ? "max-w-[468px]" : "max-w-[260px]"} min-w-[220px] flex flex-col justify-between px-6 py-7 bg-white border border-gray200 rounded-2xl h-[260px] transition-all`}
+      className={`w-full group ${longWidth ? "max-w-[468px]" : "max-w-[260px]"} min-w-[220px] flex flex-col justify-between px-6 py-7 bg-white border border-gray200 rounded-2xl h-[260px] transition-all hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime300 focus-visible:ring-offset-2`}
     >
       <div className="w-full flex justify-between">
         <div className="rounded-lg flex bg-lime50 border border-lime300 p-2.5 text-lime500">
           {cardIcon[type].icon}
         </div>
-        <Arrow_Short
+        <ArrowShort
           direction={longWidth ? "upRight" : "right"}
-          className="text-gray200 opacity-0 cursor-pointer group-hover:opacity-100 transition-all"
+          className="text-gray300 opacity-60 transition-all group-hover:opacity-100 group-hover:text-gray500"
         />
       </div>
       <div className="w-full flex flex-col gap-2">
         <p className="text-bold28 text-black">{cardIcon[type].title}</p>
         <p className="text-medium16 text-gray500">{cardIcon[type].details}</p>
       </div>
-    </div>
+    </button>
   );
+}
+
+Card.defaultProps = {
+  longWidth: false,
+  onClick: undefined,
 };

--- a/src/app/(with-header)/division/page.tsx
+++ b/src/app/(with-header)/division/page.tsx
@@ -1,11 +1,10 @@
 import { Title } from "../document/[id]/Title";
-import { Card } from "./Card";
-import StudentPage from "./student/page";
+import Card from "./Card";
 
 export default function Division() {
   return (
     <div className="w-full flex justify-center pb-12">
-      <div className="flex w-full max-w-screen-xl flex-col gap-14 px-12 pt-16">
+      <div className="flex w-full max-w-screen-xl flex-col gap-14 px-6 pt-16 sm:px-4 lg:px-12">
         <Title
           noPadding
           noShow

--- a/src/app/(with-header)/division/student/page.tsx
+++ b/src/app/(with-header)/division/student/page.tsx
@@ -15,7 +15,7 @@ function StudentPage() {
   });
   return (
     <div className="w-full flex justify-center">
-      <div className="flex w-full max-w-screen-xl flex-col">
+      <div className="flex w-full max-w-screen-xl flex-col px-6 sm:px-4 lg:px-12">
         <div className="flex w-full flex-col gap-3 pb-12 pt-28">
           <div className="rounded-md p-2 w-fit border border-gray200 bg-white hover:bg-gray50">
             <Arrow className="text-gray600" />

--- a/src/app/(with-header)/team/MemberCard.tsx
+++ b/src/app/(with-header)/team/MemberCard.tsx
@@ -11,10 +11,13 @@ interface CardProps {
 export const MemberCard = ({ name, img, github, major }: CardProps) => {
   return (
     <div className="group rounded-lg w-full max-w-[270px] h-[360px] relative overflow-hidden">
-      <div className="absolute translate-y-8 group-hover:translate-y-0 opacity-0 transition-all group-hover:opacity-100 z-10 self-center left-2.5 right-2.5 bottom-2.5 flex flex-col gap-1 p-4 rounded-md bg-white">
+      <div className="absolute bottom-2.5 left-2.5 right-2.5 z-10 flex translate-y-8 flex-col gap-1 rounded-md bg-white p-4 opacity-0 transition-all group-hover:translate-y-0 group-hover:opacity-100 sm:translate-y-0 sm:opacity-100 md:translate-y-0 md:opacity-100 lg:translate-y-8 lg:opacity-0 lg:group-hover:translate-y-0 lg:group-hover:opacity-100">
         <div className="w-full justify-between items-center flex">
           <p className="text-semibold20">{name}</p>
-          <a href={github} className="cursor-pointer">
+          <a
+            href={github}
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-gray200 bg-gray50 text-gray500 transition-all hover:bg-lime50 hover:text-lime600"
+          >
             <Github />
           </a>
         </div>
@@ -22,7 +25,8 @@ export const MemberCard = ({ name, img, github, major }: CardProps) => {
       </div>
       <img
         src={img || ""}
-        className="absolute w-full h-full grayscale group-hover:grayscale-0 transition-all"
+        alt={name ? `${name} 프로필 이미지` : "팀원 프로필 이미지"}
+        className="absolute h-full w-full grayscale transition-all group-hover:grayscale-0 sm:grayscale-0 md:grayscale-0 lg:grayscale"
       />
     </div>
   );

--- a/src/app/(with-header)/team/page.tsx
+++ b/src/app/(with-header)/team/page.tsx
@@ -60,7 +60,7 @@ export default function Team() {
   return (
     <div className="w-full flex justify-center flex-col">
       <div className="flex w-full max-w-screen-xl flex-col pt-16">
-        <div className="w-full px-6 lg:px-12 py-16 lg:py-24 gap-6 flex flex-col lg:flex-row lg:justify-between">
+        <div className="w-full px-6 py-16 sm:px-4 lg:px-12 lg:py-24 gap-6 flex flex-col lg:flex-row lg:justify-between">
           <div className="flex flex-col gap-6 bg-white">
             <p className="text-bold40">
               대마위키를 만든
@@ -77,7 +77,7 @@ export default function Team() {
             <div className="h-[500px] w-60 top-0 right-0 bg-gradient-to-t to-transparent from-white via-white absolute" />
           </div>
         </div>
-        <div className="w-full px-12 py-24 gap-12 flex flex-col">
+        <div className="w-full px-6 py-24 sm:px-4 lg:px-12 gap-12 flex flex-col">
           <div className="flex flex-col gap-6">
             <p className="text-lime500 text-semibold18">팀 DM 멤버 소개</p>
             <p className="text-bold40">저희를 소개합니다</p>
@@ -100,7 +100,7 @@ export default function Team() {
             ))}
           </div>
         </div>
-        <div className="w-full px-12 py-24 gap-12 flex flex-col">
+        <div className="w-full px-6 py-24 sm:px-4 lg:px-12 gap-12 flex flex-col">
           <div className="flex flex-col gap-6">
             <p className="text-[18px] font-bold text-lime500">
               우리들의 가치관
@@ -127,7 +127,7 @@ export default function Team() {
             className="w-max rounded-full px-4 py-3 text-medium16"
           />
         </div>
-        <div className="w-full px-12 py-24 gap-12 flex flex-col">
+        <div className="w-full px-6 py-24 sm:px-4 lg:px-12 gap-12 flex flex-col">
           <div className="flex flex-col gap-6">
             <p className="text-semibold18 text-lime500">활동 및 기술 스택</p>
             <p className="text-bold40 text-gray800">저희는 이런 걸 해요</p>
@@ -166,7 +166,7 @@ export default function Team() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col items-center gap-9 py-24 px-12 bg-gray50">
+      <div className="flex flex-col items-center gap-9 bg-gray50 px-6 py-24 sm:px-4 lg:px-12">
         <p className="text-semibold18 text-gray400">밤이 되었습니다</p>
         <p className="text-center font-semibold text-[32px] leading-9">
           대마위키와 함께하실 분은


### PR DESCRIPTION
## Summary
- Improve `/division` card click affordance with always-visible directional cue and keyboard focus treatment.
- Improve `/team` card readability on touch devices by surfacing member info without hover dependency.
- Normalize section/container gutters on division/team routes to align with shared shell rhythm.

## Validation
- `yarn tsc --noEmit`
- `yarn lint --file src/app/(with-header)/division/Card.tsx --file src/app/(with-header)/division/page.tsx --file src/app/(with-header)/division/student/page.tsx --file src/app/(with-header)/team/MemberCard.tsx --file src/app/(with-header)/team/page.tsx` *(reports pre-existing lint debt in these legacy files)*

Closes #87
Closes #95
Related: #73