### PR TITLE
[DMWCOMM-23] Finalize core route container and gutter rhythm

### DIFF
--- a/src/app/(with-header)/document/[id]/Profile.tsx
+++ b/src/app/(with-header)/document/[id]/Profile.tsx
@@ -13,7 +13,7 @@ export const Profile = () => {
   ];
 
   return (
-    <div className="w-full flex flex-col gap-8 px-12 py-8 border-b border-gray200">
+    <div className="w-full flex flex-col gap-8 border-b border-gray200 px-6 py-8 sm:px-4 lg:px-12">
       {/* Profile Section */}
       <div className="w-full flex items-start gap-6">
         <div className="w-40 h-40 rounded-full border border-gray200 bg-gray100 overflow-hidden flex-shrink-0">
@@ -26,7 +26,8 @@ export const Profile = () => {
             <p className="text-lime500 text-semibold14">2113 이태영</p>
           </div>
           <p className="text-gray600 text-medium18">
-            김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한 명입니다.
+            김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한
+            명입니다.
           </p>
         </div>
       </div>

--- a/src/app/(with-header)/document/[id]/userInfo/page.tsx
+++ b/src/app/(with-header)/document/[id]/userInfo/page.tsx
@@ -73,7 +73,7 @@ export default function UserInfo() {
       <Sidebar fixed />
       <div className="flex flex-grow max-w-screen-xl flex-col">
         <Title />
-        <div className="flex flex-col px-12 py-6 gap-20 sm:px-4 sm:gap-10">
+        <div className="flex flex-col gap-20 px-6 py-6 sm:px-4 sm:gap-10 lg:px-12">
           <div className="flex gap-20 sm:flex-col sm:gap-8">
             <div className="flex flex-col gap-5">
               <span className="text-medium20">문서 정보</span>

--- a/src/app/(with-header)/main/page.tsx
+++ b/src/app/(with-header)/main/page.tsx
@@ -118,7 +118,7 @@ function Main() {
 
   return (
     <div className="flex w-full justify-center bg-gray100 pb-28">
-      <div className="flex w-full max-w-6xl flex-col items-center px-4 md:px-4 sm:px-4">
+      <div className="flex w-full max-w-screen-xl flex-col items-center px-6 sm:px-4 lg:px-12">
         <section className="flex w-full flex-col items-center gap-8 pb-28 pt-20 text-center">
           <button
             type="button"

--- a/src/app/(with-header)/popular/page.tsx
+++ b/src/app/(with-header)/popular/page.tsx
@@ -12,7 +12,7 @@ function Popular() {
 
   return (
     <div className="flex w-full justify-center pb-12">
-      <div className="flex w-full max-w-screen-xl flex-col gap-10 px-12 pt-16">
+      <div className="flex w-full max-w-screen-xl flex-col gap-10 px-6 pt-16 sm:px-4 lg:px-12">
         <PageHeader
           title="인기 문서"
           subtitle="대마위키"


### PR DESCRIPTION
## Summary
- Normalize remaining container/gutter spacing on core routes by aligning `main`, `popular`, and document sub-sections to the shared `px-6 sm:px-4 lg:px-12` rhythm.
- Remove the remaining visual start-line drift between with-header routes.

## Validation
- `yarn tsc --noEmit`
- `yarn lint --file src/app/(with-header)/main/page.tsx --file src/app/(with-header)/popular/page.tsx --file src/app/(with-header)/document/[id]/Profile.tsx --file src/app/(with-header)/document/[id]/userInfo/page.tsx` *(reports pre-existing lint debt in legacy document profile file)*

Closes #73