### PR TITLE
[DMWCOMM-11] shared layout component lint cleanup

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,10 @@
 import { Discord, Github, Instagram, Logo } from "@/assets";
 
-export const Footer = () => {
-  const link = [
-    { icon: <Instagram size={28} />, url: "" },
-    { icon: <Discord size={28} />, url: "" },
-    { icon: <Github size={28} />, url: "" },
+function Footer() {
+  const links = [
+    { key: "instagram", icon: <Instagram size={28} /> },
+    { key: "discord", icon: <Discord size={28} /> },
+    { key: "github", icon: <Github size={28} /> },
   ];
 
   const list = [
@@ -30,8 +30,8 @@ export const Footer = () => {
               </p>
             </div>
             <div className="flex items-center gap-2 text-gray400">
-              {link.map(({ icon, url }, index) => (
-                <div key={index} className="flex p-1.5">
+              {links.map(({ icon, key }) => (
+                <div key={key} className="flex p-1.5">
                   {icon}
                 </div>
               ))}
@@ -39,17 +39,17 @@ export const Footer = () => {
           </div>
 
           <div className="flex w-full justify-end gap-6">
-            {list.map(({ title, text }, index) => (
+            {list.map(({ title, text }) => (
               <div
-                key={index}
+                key={title}
                 className="flex lg:max-w-[200px] w-full flex-col gap-2"
               >
                 <p className="text-semibold16 text-gray600 whitespace-nowrap">
                   {title}
                 </p>
-                {text.map((txt, idx) => (
+                {text.map(txt => (
                   <p
-                    key={idx}
+                    key={`${title}-${txt}`}
                     className="text-medium14 text-gray400 whitespace-nowrap"
                   >
                     {txt}
@@ -62,7 +62,10 @@ export const Footer = () => {
         <div className="w-full flex flex-col gap-4">
           <div className="flex w-full items-end flex-wrap gap-6 py-4 border-b border-gray200">
             {info.map(({ title, details }) => (
-              <div className="flex w-full max-w-[200px] flex-col gap-2">
+              <div
+                key={title}
+                className="flex w-full max-w-[200px] flex-col gap-2"
+              >
                 <p className="text-medium12 text-gray400">{title}</p>
                 <p className="text-medium14 text-gray600 whitespace-nowrap">
                   {details}
@@ -81,4 +84,7 @@ export const Footer = () => {
       </div>
     </div>
   );
-};
+}
+
+export { Footer };
+export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { Logo, Arrow, User, Search } from "@/assets";
-import React from "react";
-import { SearchInput } from "@/components";
-import { usePathname, useRouter } from "next/navigation";
-import { getCookie } from "@/apis/cookies";
 
-export const Header = () => {
+import React from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+import { getCookie } from "@/apis/cookies";
+import { Arrow, Logo, Search, User } from "@/assets";
+import { SearchInput } from "@/components/SearchInput";
+
+function Header() {
   const router = useRouter();
   const pathname = usePathname();
   const navList = [
@@ -151,4 +153,7 @@ export const Header = () => {
       </div>
     </div>
   );
-};
+}
+
+export { Header };
+export default Header;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,34 +1,87 @@
 "use client";
-import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { Arrow_Double, Edit, Info, Setting, Slash } from "@/assets";
-import { SearchInput } from "@/components";
 
-interface ListProps {
-  icon: React.ReactNode;
+import { useEffect, useState } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+
+import {
+  Arrow_Double as ArrowDouble,
+  Edit,
+  Info,
+  Setting,
+  Slash,
+} from "@/assets";
+import { SearchInput } from "@/components/SearchInput";
+
+interface SidebarListItemProps {
+  icon: ReactNode;
   text: string;
-  indexList?: boolean;
-  padding?: number;
-  onClick?: () => void;
+  isIndexList: boolean;
+  paddingLevel: number;
+  onClick: () => void;
 }
 
 interface SidebarProps {
   fixed?: boolean;
   setOpenSidebar?: Dispatch<SetStateAction<boolean>>;
-  titleList?: titleListProps[];
+  titleList?: TitleListProps[];
 }
 
-interface titleListProps {
+interface TitleListProps {
   num: string;
   title: string;
 }
 
-export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
+const defaultSetOpenSidebar: Dispatch<SetStateAction<boolean>> = () =>
+  undefined;
+
+function getPaddingClass(paddingLevel: number): string {
+  if (paddingLevel === 2) {
+    return "pl-5";
+  }
+
+  if (paddingLevel === 3) {
+    return "pl-[30px]";
+  }
+
+  return "pl-2.5";
+}
+
+function SidebarListItem({
+  icon,
+  text,
+  isIndexList,
+  paddingLevel,
+  onClick,
+}: SidebarListItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full peer transition-all flex items-center text-gray600 overflow-hidden text-nowrap rounded-lg ${isIndexList ? "gap-2" : "gap-3"} py-2.5 pr-2.5 ${getPaddingClass(paddingLevel)} bg-white ${isIndexList ? "hover:bg-lime50" : "hover:bg-gray100"}`}
+    >
+      {icon}
+      <p
+        className={`${isIndexList ? "text-medium18" : "text-medium16"} overflow-hidden overflow-ellipsis text-nowrap`}
+      >
+        {text}
+      </p>
+    </button>
+  );
+}
+
+function Sidebar({
+  fixed = false,
+  setOpenSidebar = defaultSetOpenSidebar,
+  titleList = [],
+}: SidebarProps) {
   const [visible, setVisible] = useState<boolean>(true);
-  const tocList = titleList ?? [];
-  const isFixed = fixed ?? false;
+  const tocList = titleList;
+  const isFixed = fixed;
 
   useEffect(() => {
-    if (isFixed) return;
+    if (isFixed) {
+      return () => {};
+    }
 
     const desktopMedia = window.matchMedia("(min-width: 1420px)");
 
@@ -46,30 +99,24 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
   }, [isFixed]);
 
   useEffect(() => {
-    if (!setOpenSidebar) return;
     setOpenSidebar(visible);
   }, [setOpenSidebar, visible]);
+
   const listArr = [
     { icon: <Edit size={22} />, text: "문서 수정" },
     { icon: <Info size={22} />, text: "문서 정보" },
     { icon: <Setting size={22} />, text: "설정" },
   ];
 
-  const List = ({ icon, text, indexList, padding, onClick }: ListProps) => {
-    return (
-      <div
-        onClick={onClick}
-        className={`w-full cursor-pointer peer transition-all flex items-center text-gray600 overflow-hidden text-nowrap rounded-lg ${indexList ? "gap-2" : "gap-3"} py-2.5 pr-2.5 ${padding == 2 ? "pl-5" : padding == 3 ? "pl-[30px]" : "pl-2.5"} bg-white ${indexList ? "hover:bg-lime50" : "hover:bg-gray100"}`}
-      >
-        {icon}
-        <p
-          className={`${indexList ? "text-medium18" : "text-medium16"} overflow-hidden overflow-ellipsis text-nowrap`}
-        >
-          {text}
-        </p>
-      </div>
-    );
+  const handleOpenSidebar = () => {
+    setVisible(true);
   };
+
+  const handleToggleSidebar = () => {
+    setVisible(prev => !prev);
+  };
+
+  const handleNoop = () => undefined;
 
   return (
     <>
@@ -77,11 +124,11 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
         <>
           <button
             type="button"
-            onClick={() => setVisible(true)}
+            onClick={handleOpenSidebar}
             aria-label="목차 열기"
             className="fixed bottom-6 right-4 z-30 flex items-center gap-2 rounded-full border border-lime300 bg-lime50 px-4 py-2 text-semibold16 text-lime600 shadow-md transition hover:bg-lime100 lg:hidden"
           >
-            <Arrow_Double
+            <ArrowDouble
               className="text-lime500 transition-all"
               direction="right"
             />
@@ -89,11 +136,11 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
           </button>
           <button
             type="button"
-            onClick={() => setVisible(true)}
+            onClick={handleOpenSidebar}
             aria-label="사이드바 열기"
             className="fixed left-0 top-24 z-30 hidden h-10 w-10 items-center justify-center rounded-r-xl border border-l-0 border-gray300 bg-white text-gray400 shadow-sm transition hover:bg-gray50 lg:flex"
           >
-            <Arrow_Double
+            <ArrowDouble
               className="text-gray400 transition-all"
               direction="right"
             />
@@ -118,10 +165,10 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
             <button
               type="button"
               aria-label="사이드바 닫기"
-              onClick={() => setVisible(!visible)}
+              onClick={handleToggleSidebar}
               className="absolute right-4 top-3.5 flex p-1 transition-all"
             >
-              <Arrow_Double
+              <ArrowDouble
                 className="text-gray400 transition-all"
                 direction={visible ? "left" : "right"}
               />
@@ -133,8 +180,15 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
           <div className="w-full flex flex-col gap-2">
             <p className="text-semibold14 text-gray600">설정</p>
             <div className="flex w-full gap-1 flex-col">
-              {listArr.map(({ icon, text }, index) => (
-                <List key={index} icon={icon} text={text} />
+              {listArr.map(({ icon, text }) => (
+                <SidebarListItem
+                  key={text}
+                  icon={icon}
+                  text={text}
+                  isIndexList={false}
+                  paddingLevel={1}
+                  onClick={handleNoop}
+                />
               ))}
             </div>
           </div>
@@ -142,11 +196,11 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
             <div className="w-full flex flex-col gap-2">
               <p className="text-semibold14 text-gray600">목차</p>
               <div className="flex w-full gap-1 flex-col">
-                {tocList.map(({ num, title }, index) => (
-                  <List
-                    padding={num.split(".").length}
-                    indexList
-                    key={index}
+                {tocList.map(({ num, title }) => (
+                  <SidebarListItem
+                    paddingLevel={num.split(".").length}
+                    isIndexList
+                    key={`${num}-${title}`}
                     icon={<p className="text-semibold18 text-lime500">{num}</p>}
                     text={title}
                     onClick={() => {
@@ -169,4 +223,13 @@ export const Sidebar = ({ fixed, setOpenSidebar, titleList }: SidebarProps) => {
       </div>
     </>
   );
+}
+
+Sidebar.defaultProps = {
+  fixed: false,
+  setOpenSidebar: defaultSetOpenSidebar,
+  titleList: [],
 };
+
+export { Sidebar };
+export default Sidebar;


### PR DESCRIPTION
## Summary
- clean up lint violations in `src/components/Header.tsx`, `src/components/Footer.tsx`, and `src/components/Sidebar.tsx`
- keep runtime behavior unchanged while converting to function declarations/default+named exports where required by lint rules
- remove barrel-import cycles for layout components by importing `SearchInput` directly

## Verification
- `yarn lint --file src/components/Header.tsx --file src/components/Footer.tsx --file src/components/Sidebar.tsx`
- `yarn tsc --noEmit`

Closes #59