### PR TITLE
[DMWCOMM-12] component input/button lint cleanup

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -12,7 +12,7 @@ interface ButtonProps {
   children?: Readonly<React.ReactNode>;
 }
 
-export const Button = ({
+function Button({
   text,
   onClick,
   style = "primary",
@@ -22,7 +22,7 @@ export const Button = ({
   disabled = false,
   className = "",
   children,
-}: ButtonProps) => {
+}: ButtonProps) {
   const isDisabled = state === "disabled" || disabled;
 
   const buttonStyle = {
@@ -48,21 +48,52 @@ export const Button = ({
     },
   };
 
+  const buttonClassName = `inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime300 focus-visible:ring-offset-2 ${
+    big
+      ? "min-h-12 rounded-lg px-4 py-3 text-semibold18"
+      : "min-h-10 rounded-md px-3 py-2 text-semibold16"
+  } ${buttonStyle[style][isDisabled ? "disabled" : "enabled"]} ${
+    isDisabled ? "cursor-not-allowed" : "cursor-pointer"
+  } ${className}`;
+
+  if (type === "submit") {
+    return (
+      <button
+        type="submit"
+        onClick={onClick}
+        disabled={isDisabled}
+        className={buttonClassName}
+      >
+        {text}
+        {children}
+      </button>
+    );
+  }
+
   return (
     <button
-      type={type}
+      type="button"
       onClick={onClick}
       disabled={isDisabled}
-      className={`inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime300 focus-visible:ring-offset-2 ${
-        big
-          ? "min-h-12 rounded-lg px-4 py-3 text-semibold18"
-          : "min-h-10 rounded-md px-3 py-2 text-semibold16"
-      } ${buttonStyle[style][isDisabled ? "disabled" : "enabled"]} ${
-        isDisabled ? "cursor-not-allowed" : "cursor-pointer"
-      } ${className}`}
+      className={buttonClassName}
     >
       {text}
       {children}
     </button>
   );
+}
+
+Button.defaultProps = {
+  text: "",
+  style: "primary",
+  state: "enabled",
+  onClick: undefined,
+  big: false,
+  type: "button",
+  disabled: false,
+  className: "",
+  children: null,
 };
+
+export { Button };
+export default Button;

--- a/src/components/RegisterInput.tsx
+++ b/src/components/RegisterInput.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Arrow, Hide, Show } from "@/assets";
 import {
   formFieldContainerClass,
@@ -18,11 +19,11 @@ interface InputProps {
   value?: string | number;
   type?: "email" | "password" | "text" | "dropdown";
   dropdownValue?: string[] | number[];
-  onChange?: (...e: any[]) => void;
+  onChange?: (value: string) => void;
   autoFocus?: boolean;
 }
 
-export const RegisterInput = ({
+function RegisterInput({
   title,
   placeholder,
   type = "text",
@@ -30,16 +31,21 @@ export const RegisterInput = ({
   value,
   onChange,
   dropdownValue,
-  autoFocus,
-}: InputProps) => {
+  autoFocus = false,
+}: InputProps) {
   const [hidePassword, setHidePassword] = useState<boolean>(true); // 비밀번호 숨기기
   const [dropdownOpen, setDropdownOpen] = useState<boolean>(false); // 드롭다운 열기
   const inputRef = useRef<HTMLDivElement>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
+
+  const toggleDropdownOpen = () => {
+    setDropdownOpen(prev => !prev);
+  };
 
   // 드롭다운에서 선택한 값을 업데이트하는 함수
   const handleDropdownChange = (item: string | number) => {
     if (onChange) {
-      onChange(item); // 선택된 값을 직접 전달
+      onChange(String(item)); // 선택된 값을 직접 전달
     }
     setDropdownOpen(false); // 드롭다운 닫기
   };
@@ -61,6 +67,12 @@ export const RegisterInput = ({
     };
   }, []);
 
+  useEffect(() => {
+    if (autoFocus && type !== "dropdown") {
+      textInputRef.current?.focus();
+    }
+  }, [autoFocus, type]);
+
   const inputType = {
     email: (
       <div className="flex px-3">
@@ -70,21 +82,28 @@ export const RegisterInput = ({
       </div>
     ),
     password: (
-      <div
-        onClick={() => setHidePassword(!hidePassword)}
+      <button
+        type="button"
+        onClick={() => setHidePassword(prev => !prev)}
         className="flex items-center justify-center px-3 text-gray500 cursor-pointer"
+        aria-label={hidePassword ? "비밀번호 표시" : "비밀번호 숨기기"}
       >
         {hidePassword ? <Hide /> : <Show />}
-      </div>
+      </button>
     ),
-    text: <></>,
+    text: null,
     dropdown: (
-      <div className="p-3 flex cursor-pointer">
+      <button
+        type="button"
+        onClick={toggleDropdownOpen}
+        className="p-3 flex cursor-pointer"
+        aria-label="드롭다운 열기"
+      >
         <Arrow
           className="text-gray600 transition-all"
           direction={dropdownOpen ? "up" : "down"}
         />
-      </div>
+      </button>
     ),
   };
 
@@ -92,17 +111,14 @@ export const RegisterInput = ({
     <div className={formFieldContainerClass} ref={inputRef}>
       <div className={formFieldWrapperClass}>
         <div className={formFieldLabelClass}>{title}</div>
-        <div
-          onClick={() => type === "dropdown" && setDropdownOpen(!dropdownOpen)}
-          className={formFieldInputRowClass}
-        >
+        <div className={formFieldInputRowClass}>
           {type === "dropdown" ? (
             <div className={formFieldDropdownTextClass}>
               {value || placeholder}
             </div>
           ) : (
             <input
-              autoFocus={autoFocus}
+              ref={textInputRef}
               value={value}
               onChange={e => onChange?.(e.target.value)}
               type={hidePassword && type === "password" ? "password" : "text"}
@@ -131,4 +147,18 @@ export const RegisterInput = ({
       <p className={formFieldErrorClass}>{error}</p>
     </div>
   );
+}
+
+RegisterInput.defaultProps = {
+  title: "",
+  placeholder: "",
+  error: "",
+  value: "",
+  type: "text",
+  dropdownValue: [],
+  onChange: undefined,
+  autoFocus: false,
 };
+
+export { RegisterInput };
+export default RegisterInput;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -5,7 +5,7 @@ interface InputProps {
   placeholder?: string;
 }
 
-export const SearchInput = ({ placeholder }: InputProps) => {
+function SearchInput({ placeholder }: InputProps) {
   return (
     <div className="flex min-h-10 w-full items-center gap-2 overflow-hidden rounded-md border border-gray200 bg-gray50 px-3 py-2 transition-all focus-within:bg-white">
       <input
@@ -17,4 +17,11 @@ export const SearchInput = ({ placeholder }: InputProps) => {
       </div>
     </div>
   );
+}
+
+SearchInput.defaultProps = {
+  placeholder: "",
 };
+
+export { SearchInput };
+export default SearchInput;

--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -2,34 +2,43 @@ interface CategoryProps {
   groups: string[][];
 }
 
-const Category = ({ groups }: CategoryProps) => {
+function Category({ groups }: CategoryProps) {
   const renderGroups = () => {
-    const formatGroups = groups.map((group, index) => {
-      const format = group.map((item, index) => {
-        const isLastItem = index === group.length - 1;
+    const formatGroups = groups.map((group, groupIndex) => {
+      const groupLabel = group.join("|");
+      const format = group.map((item, itemIndex) => {
+        const isLastItem = itemIndex === group.length - 1;
+
         return (
-          <span className="text-myDocumentNameColor flex gap-[6px]">
+          <span
+            key={`${groupLabel}-${item}`}
+            className="text-myDocumentNameColor flex gap-[6px]"
+          >
             {`${item}`}
             <span>{isLastItem ? "" : "/"}</span>
           </span>
         );
       });
-      const isLastGroup = index === groups.length - 1;
+
+      const isLastGroup = groupIndex === groups.length - 1;
+
       return (
-        <span className="flex gap-[10px]">
+        <span key={groupLabel} className="flex gap-[10px]">
           <span className="flex gap-[6px]">{format}</span>
           {isLastGroup ? "" : "|"}
         </span>
       );
     });
+
     return <div className="flex gap-[10px]">{formatGroups}</div>;
   };
+
   return (
     <div className="flex gap-[10px] px-[10px] py-[8px] border-[#d2d2d2] border-[1px] rounded-[4px]">
       <span>분류 :</span>
       {renderGroups()}
     </div>
   );
-};
+}
 
 export default Category;


### PR DESCRIPTION
## Summary
- clean up lint issues in `Button`, `SearchInput`, `RegisterInput`, and `category` components
- add explicit defaults/exports and a11y-safe interactive elements for register input controls
- tighten `RegisterInput` change typing and keep dropdown/text behavior intact

## Verification
- `yarn lint --file src/components/Button.tsx --file src/components/SearchInput.tsx --file src/components/RegisterInput.tsx --file src/components/category.tsx`
- `yarn tsc --noEmit`

Closes #60