### PR TITLE
[DMWCOMM-17A] root screenshot artifact triage policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,39 @@ yarn-error.log*
 next-env.d.ts
 
 .env
+
+# local UI audit artifacts (root only)
+# keep retained captures under docs/artifacts/
+/agent*.png
+/agent*.jpg
+/agent*.jpeg
+/audit*.png
+/audit*.jpg
+/audit*.jpeg
+/desktop-*.png
+/desktop-*.jpg
+/desktop-*.jpeg
+/dmwcomm*.png
+/dmwcomm*.jpg
+/dmwcomm*.jpeg
+/main-*.png
+/main-*.jpg
+/main-*.jpeg
+/mobile-*.png
+/mobile-*.jpg
+/mobile-*.jpeg
+/popular-*.png
+/popular-*.jpg
+/popular-*.jpeg
+/pr*.png
+/pr*.jpg
+/pr*.jpeg
+/shell-audit-*.png
+/shell-audit-*.jpg
+/shell-audit-*.jpeg
+/ui*.png
+/ui*.jpg
+/ui*.jpeg
+/worktree-*.png
+/worktree-*.jpg
+/worktree-*.jpeg

--- a/docs/artifacts/README.md
+++ b/docs/artifacts/README.md
@@ -1,0 +1,26 @@
+# UI Artifact Policy
+
+This directory is the only approved location for retained UI audit screenshots.
+
+## Scope
+
+- Root-level ad-hoc capture files are not retained in repository history.
+- Root-level capture patterns are ignored by `.gitignore` to prevent working-tree pollution.
+- Keep only evidence needed for merged PR review or release notes.
+
+## Retention Rules
+
+1. Keep final before/after evidence only.
+2. Delete transient debug captures (multiple retries, viewport probes, one-off checks).
+3. Use deterministic names:
+   - `<issue>-<route>-<viewport>-<state>.png`
+   - example: `dmwcomm-17-main-1440x900-after.png`
+
+## Suggested Local Cleanup Flow
+
+```bash
+mkdir -p docs/artifacts/ui-audit
+mv ./audit*.png ./agent*.png ./pr*.png ./ui*.png docs/artifacts/ui-audit/ 2>/dev/null
+```
+
+Review moved files, keep final artifacts only, and delete the rest before commit.


### PR DESCRIPTION
## Summary
- add root-level screenshot artifact ignore guardrails in `.gitignore` for common audit/debug capture prefixes
- add deterministic retention policy under `docs/artifacts/README.md`
- document relocation target (`docs/artifacts/ui-audit/`) and cleanup flow to prevent root working-tree pollution

## Verification
- `git check-ignore -v audit-temp.png pr-example-390x844.jpeg docs/artifacts/README.md`
- `yarn tsc --noEmit`

## Issues
- closes #108
- refs #67