### PR TITLE
[DMWCOMM-17D-1] division route parity checklist

### DIFF
--- a/docs/plans/2026-02-16-dmwcomm-17d1-division-parity-checklist.md
+++ b/docs/plans/2026-02-16-dmwcomm-17d1-division-parity-checklist.md
@@ -1,0 +1,50 @@
+# DMWCOMM-17D-1 Division Parity Checklist
+
+## Scope
+
+- Route domain: `/division`
+- Compared refs: `origin/dev` vs `feature/FO-5-1`
+- Files inspected:
+  - `src/app/(with-header)/division/page.tsx`
+  - `src/app/(with-header)/division/Card.tsx`
+  - `src/app/(with-header)/division/student/page.tsx`
+
+## Delta review
+
+### 1) `division/page.tsx`
+
+- FO-only delta: imports `StudentPage` but does not use it.
+- Current dev state: no dead import, responsive container classes are already applied.
+- Decision: **reject FO delta** (stale and lower quality).
+
+### 2) `division/Card.tsx`
+
+- FO-only delta: clickable `<div>` usage and weaker hover/focus affordance.
+- Current dev state: semantic `<button>`, keyboard focus ring, improved interaction classes.
+- Decision: **reject FO delta** (current dev is preferred accessibility baseline).
+
+### 3) `division/student/page.tsx`
+
+- FO-only delta: narrower fixed-width layout baseline (`max-w-[1200px]`) and no responsive horizontal padding set used in dev.
+- Current dev state: responsive layout with `max-w-screen-xl` + `px-6 sm:px-4 lg:px-12`.
+- Decision: **reject FO delta** (current dev has better responsive behavior).
+
+## Accepted parity deltas
+
+- None for this route.
+
+## Route implementation action
+
+- No code changes required for `/division` in this parity cycle.
+- Division route remains on current `origin/dev` implementation.
+
+## Verification evidence
+
+- Division-domain diff exists only in the three files listed above.
+- No route code changes were applied in this ticket.
+- Typecheck gate still passes (`yarn tsc --noEmit`).
+
+## Result
+
+- `/division` parity evaluation complete.
+- Route baseline explicitly locked to current `origin/dev` implementation.


### PR DESCRIPTION
## Summary
- add division-route parity checklist in `docs/plans/2026-02-16-dmwcomm-17d1-division-parity-checklist.md`
- compare `origin/dev` vs `feature/FO-5-1` deltas for division-domain files
- record reject decisions for FO-only regressions and lock baseline to current dev implementation

## Verification
- `git diff --name-status origin/dev feature/FO-5-1 -- "src/app/(with-header)/division"`
- `yarn tsc --noEmit`

## Issues
- closes #116
- refs #111 #67