### PR TITLE
[DMWCOMM-17D-2] recent route parity checklist

### DIFF
--- a/docs/plans/2026-02-16-dmwcomm-17d2-recent-parity-checklist.md
+++ b/docs/plans/2026-02-16-dmwcomm-17d2-recent-parity-checklist.md
@@ -1,0 +1,50 @@
+# DMWCOMM-17D-2 Recent Parity Checklist
+
+## Scope
+
+- Route domain: `/recent`
+- Compared refs: `origin/dev` vs `feature/FO-5-1`
+- Files inspected:
+  - `src/app/(with-header)/recent/List.tsx`
+  - `src/app/(with-header)/recent/Pagination.tsx`
+  - `src/app/(with-header)/recent/page.tsx`
+
+## Delta review
+
+### 1) `recent/List.tsx`
+
+- FO-only delta: looser optional typing and non-responsive row layout.
+- Current dev state: explicit string props, responsive grid layout, default-prop lint compatibility.
+- Decision: **reject FO delta** (current dev has better typing and responsive behavior).
+
+### 2) `recent/Pagination.tsx`
+
+- FO-only delta: clickable `<div>` controls and index-key mapping.
+- Current dev state: semantic `<button>` controls, accessible labels, stable item keys.
+- Decision: **reject FO delta** (current dev is preferred accessibility baseline).
+
+### 3) `recent/page.tsx`
+
+- FO-only delta: fixed-width container (`max-w-[1200px]`), array-index keys, non-deterministic item identity.
+- Current dev state: responsive container classes and stable generated ids (`recent-${index + 1}`).
+- Decision: **reject FO delta** (current dev has better responsive and key stability behavior).
+
+## Accepted parity deltas
+
+- None for this route.
+
+## Route implementation action
+
+- No code changes required for `/recent` in this parity cycle.
+- Recent route remains on current `origin/dev` implementation.
+
+## Verification evidence
+
+- Recent-domain diff exists only in the three files listed above.
+- No route code changes were applied in this ticket.
+- Typecheck gate still passes (`yarn tsc --noEmit`).
+
+## Result
+
+- `/recent` parity evaluation complete.
+- Route baseline explicitly locked to current `origin/dev` implementation.


### PR DESCRIPTION
## Summary
- add recent-route parity checklist in `docs/plans/2026-02-16-dmwcomm-17d2-recent-parity-checklist.md`
- compare `origin/dev` vs `feature/FO-5-1` deltas for recent-domain files
- record reject decisions for FO-only regressions and lock baseline to current dev implementation

## Verification
- `git diff --name-status origin/dev feature/FO-5-1 -- "src/app/(with-header)/recent"`
- `yarn tsc --noEmit`

## Issues
- closes #117
- refs #111 #67