### PR TITLE
[DMWCOMM-17D-3] team route parity checklist

### DIFF
--- a/docs/plans/2026-02-16-dmwcomm-17d3-team-parity-checklist.md
+++ b/docs/plans/2026-02-16-dmwcomm-17d3-team-parity-checklist.md
@@ -1,0 +1,54 @@
+# DMWCOMM-17D-3 Team Parity Checklist
+
+## Scope
+
+- Route domain: `/team`
+- Compared refs: `origin/dev` vs `feature/FO-5-1`
+- Files inspected:
+  - `src/app/(with-header)/team/page.tsx`
+  - `src/app/(with-header)/team/MemberCard.tsx`
+  - `src/app/(with-header)/team/ValuesCard.tsx`
+
+## Delta review
+
+### 1) `team/page.tsx`
+
+- FO-only deltas include:
+  - fixed-width layout baseline (`max-w-[1200px]`, `px-12`) instead of responsive container classes,
+  - array-index keys in member/rules maps,
+  - plain `<button>` usage with invalid `style` prop patterns previously seen in this route,
+  - unused imports/hooks (`Arrow`, `RegisterInput`, `useRouter`).
+- Current dev state: responsive layout, stable ids/keys, lint-safe button classes, unused imports removed.
+- Decision: **reject FO deltas** (current dev is cleaner and more robust).
+
+### 2) `team/MemberCard.tsx`
+
+- FO-only deltas include optional props without defaults, weaker link styling, and missing explicit exports used by current route import policy.
+- Current dev state: explicit required props, default+named export compatibility, improved interaction styling.
+- Decision: **reject FO delta** (current dev better matches lint/accessibility conventions).
+
+### 3) `team/ValuesCard.tsx`
+
+- FO-only delta keeps only named export style used before lint cleanup.
+- Current dev state: function declaration with default+named export compatibility for import rules.
+- Decision: **reject FO delta** (current dev aligns with current lint constraints).
+
+## Accepted parity deltas
+
+- None for this route.
+
+## Route implementation action
+
+- No code changes required for `/team` in this parity cycle.
+- Team route remains on current `origin/dev` implementation.
+
+## Verification evidence
+
+- Team-domain diff exists only in the three files listed above.
+- No route code changes were applied in this ticket.
+- Typecheck gate still passes (`yarn tsc --noEmit`).
+
+## Result
+
+- `/team` parity evaluation complete.
+- Route baseline explicitly locked to current `origin/dev` implementation.


### PR DESCRIPTION
## Summary
- add team-route parity checklist in `docs/plans/2026-02-16-dmwcomm-17d3-team-parity-checklist.md`
- compare `origin/dev` vs `feature/FO-5-1` deltas for team-domain files
- record reject decisions for FO-only regressions and lock baseline to current dev implementation

## Verification
- `git diff --name-status origin/dev feature/FO-5-1 -- "src/app/(with-header)/team"`
- `yarn tsc --noEmit`

## Issues
- closes #118
- refs #111 #67