### PR TITLE
[DMWCOMM-17D-4] main route parity checklist

### DIFF
--- a/docs/plans/2026-02-16-dmwcomm-17d4-main-parity-checklist.md
+++ b/docs/plans/2026-02-16-dmwcomm-17d4-main-parity-checklist.md
@@ -1,0 +1,36 @@
+# DMWCOMM-17D-4 Main Parity Checklist
+
+## Scope
+
+- Route domain: `/main`
+- Compared refs: `origin/dev` vs `feature/FO-5-1`
+- File inspected:
+  - `src/app/(with-header)/main/page.tsx`
+
+## Delta review
+
+### `main/page.tsx`
+
+- FO-only state: route is a stub (`return <></>`).
+- Current dev state: full main page implementation with hero, featured docs, people section, guide tabs, and CTA flow.
+- Decision: **reject FO delta** (FO state is stale and functionally incomplete).
+
+## Accepted parity deltas
+
+- None for this route.
+
+## Route implementation action
+
+- No code changes required for `/main` in this parity cycle.
+- Main route remains on current `origin/dev` implementation.
+
+## Verification evidence
+
+- Main-domain diff confirms single-file route delta against FO branch.
+- No route code changes were applied in this ticket.
+- Typecheck gate still passes (`yarn tsc --noEmit`).
+
+## Result
+
+- `/main` parity evaluation complete.
+- Route baseline explicitly locked to current `origin/dev` implementation.


### PR DESCRIPTION
## Summary
- add main-route parity checklist in `docs/plans/2026-02-16-dmwcomm-17d4-main-parity-checklist.md`
- compare `origin/dev` vs `feature/FO-5-1` delta for main route file
- record reject decision for FO stub state and lock baseline to current dev implementation

## Verification
- `git diff --name-status origin/dev feature/FO-5-1 -- "src/app/(with-header)/main"`
- `yarn tsc --noEmit`

## Issues
- closes #119
- refs #111 #67