### PR TITLE
[DMWCOMM-17D-5] popular route parity checklist

### DIFF
--- a/docs/plans/2026-02-16-dmwcomm-17d5-popular-parity-checklist.md
+++ b/docs/plans/2026-02-16-dmwcomm-17d5-popular-parity-checklist.md
@@ -1,0 +1,36 @@
+# DMWCOMM-17D-5 Popular Parity Checklist
+
+## Scope
+
+- Route domain: `/popular`
+- Compared refs: `origin/dev` vs `feature/FO-5-1`
+- File inspected:
+  - `src/app/(with-header)/popular/page.tsx`
+
+## Delta review
+
+### `popular/page.tsx`
+
+- FO-only state: route is a stub (`return <></>`).
+- Current dev state: query-backed popular page implementation using wiki modules (`fetchPopularDocuments`, `DocumentTable`, `PageHeader`, `PageSection`).
+- Decision: **reject FO delta** (FO state is stale and functionally incomplete).
+
+## Accepted parity deltas
+
+- None for this route.
+
+## Route implementation action
+
+- No code changes required for `/popular` in this parity cycle.
+- Popular route remains on current `origin/dev` implementation.
+
+## Verification evidence
+
+- Popular-domain diff confirms single-file route delta against FO branch.
+- No route code changes were applied in this ticket.
+- Typecheck gate still passes (`yarn tsc --noEmit`).
+
+## Result
+
+- `/popular` parity evaluation complete.
+- Route baseline explicitly locked to current `origin/dev` implementation.


### PR DESCRIPTION
## Summary
- add popular-route parity checklist in `docs/plans/2026-02-16-dmwcomm-17d5-popular-parity-checklist.md`
- compare `origin/dev` vs `feature/FO-5-1` delta for popular route file
- record reject decision for FO stub state and lock baseline to current dev implementation

## Verification
- `git diff --name-status origin/dev feature/FO-5-1 -- "src/app/(with-header)/popular"`
- `yarn tsc --noEmit`

## Issues
- closes #120
- refs #111 #67