### PR TITLE
[DMWCOMM-22] integrate recent and division pages with wiki APIs

### DIFF
--- a/src/apis/wiki.ts
+++ b/src/apis/wiki.ts
@@ -1,4 +1,9 @@
-import { WikiCategory, WikiDocumentSummary } from "@/interfaces/wiki";
+import {
+  WikiCategory,
+  WikiDivisionCategory,
+  WikiDocumentSummary,
+  WikiRecentChange,
+} from "@/interfaces/wiki";
 
 const categoryLabelMap: Record<WikiCategory, string> = {
   student: "학생",
@@ -50,6 +55,82 @@ const popularDocuments: WikiDocumentSummary[] = [
   },
 ];
 
+const recentChanges: WikiRecentChange[] = [
+  {
+    id: "recent-1",
+    title: "이태영",
+    category: "student",
+    editor: "김승원",
+    updatedAt: "2026-02-14 08:37",
+  },
+  {
+    id: "recent-2",
+    title: "최선생",
+    category: "teacher",
+    editor: "박지민",
+    updatedAt: "2026-02-14 08:12",
+  },
+  {
+    id: "recent-3",
+    title: "2025 해커톤 빌드 실패",
+    category: "accident",
+    editor: "김어진",
+    updatedAt: "2026-02-14 07:58",
+  },
+  {
+    id: "recent-4",
+    title: "AI 동아리",
+    category: "club",
+    editor: "이태영",
+    updatedAt: "2026-02-14 07:45",
+  },
+  {
+    id: "recent-5",
+    title: "김어진",
+    category: "student",
+    editor: "유지우",
+    updatedAt: "2026-02-14 07:20",
+  },
+  {
+    id: "recent-6",
+    title: "박지민",
+    category: "student",
+    editor: "김승원",
+    updatedAt: "2026-02-14 06:58",
+  },
+  {
+    id: "recent-7",
+    title: "야간자습 운영 규정",
+    category: "teacher",
+    editor: "Daybreak",
+    updatedAt: "2026-02-14 06:30",
+  },
+  {
+    id: "recent-8",
+    title: "동아리실 배정 변경",
+    category: "club",
+    editor: "김어진",
+    updatedAt: "2026-02-14 06:15",
+  },
+];
+
+const divisionCategories: WikiDivisionCategory[] = [
+  {
+    id: "student",
+    featured: true,
+    route: "/division/student",
+  },
+  {
+    id: "teacher",
+  },
+  {
+    id: "accident",
+  },
+  {
+    id: "club",
+  },
+];
+
 const wait = <T>(value: T) =>
   new Promise<T>(resolve => {
     setTimeout(() => resolve(value), 120);
@@ -60,3 +141,15 @@ export const wikiCategoryLabel = (category: WikiCategory) =>
 
 export const fetchPopularDocuments = async (): Promise<WikiDocumentSummary[]> =>
   wait(popularDocuments);
+
+export const fetchRecentChanges = async (): Promise<WikiRecentChange[]> =>
+  wait(recentChanges);
+
+export const fetchRecentChangesByCategory = async (
+  category: WikiCategory,
+): Promise<WikiRecentChange[]> =>
+  wait(recentChanges.filter(change => change.category === category));
+
+export const fetchDivisionCategories = async (): Promise<
+  WikiDivisionCategory[]
+> => wait(divisionCategories);

--- a/src/app/(with-header)/division/page.tsx
+++ b/src/app/(with-header)/division/page.tsx
@@ -1,7 +1,39 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { fetchDivisionCategories } from "@/apis";
+import { WikiDivisionCategory } from "@/interfaces/wiki";
 import { Title } from "../document/[id]/Title";
 import Card from "./Card";
 
+const defaultCategories: WikiDivisionCategory[] = [
+  {
+    id: "student",
+    featured: true,
+    route: "/division/student",
+  },
+  {
+    id: "teacher",
+  },
+  {
+    id: "accident",
+  },
+  {
+    id: "club",
+  },
+];
+
 export default function Division() {
+  const router = useRouter();
+  const { data, isLoading } = useQuery({
+    queryKey: ["division-categories"],
+    queryFn: fetchDivisionCategories,
+  });
+
+  const categories = data ?? defaultCategories;
+
   return (
     <div className="w-full flex justify-center pb-12">
       <div className="flex w-full max-w-screen-xl flex-col gap-14 px-6 pt-16 sm:px-4 lg:px-12">
@@ -12,11 +44,24 @@ export default function Division() {
           group="대마위키"
           details="카테고리"
         />
+        {isLoading && (
+          <p className="text-medium14 text-gray500">
+            분류를 불러오는 중입니다...
+          </p>
+        )}
         <div className="w-full flex-wrap gap-6 py-12 flex">
-          <Card longWidth type="student" />
-          <Card type="teacher" />
-          <Card type="accident" />
-          <Card type="club" />
+          {categories.map(category => {
+            const { id, featured, route } = category;
+
+            return (
+              <Card
+                key={id}
+                longWidth={featured}
+                type={id}
+                onClick={route ? () => router.push(route) : undefined}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/app/(with-header)/division/student/page.tsx
+++ b/src/app/(with-header)/division/student/page.tsx
@@ -1,18 +1,30 @@
+"use client";
+
+import { fetchRecentChangesByCategory, wikiCategoryLabel } from "@/apis";
+import { useQuery } from "@tanstack/react-query";
 import React from "react";
 import { Arrow } from "@/assets";
-import { Title } from "../../document/[id]/Title";
 import { RegisterInput } from "@/components";
 import { periodMenu, majorMenu, clubMenu } from "@/constant/dropdownItem";
+import { Title } from "../../document/[id]/Title";
 import { Pagination } from "../../recent/Pagination";
 import { List } from "../../recent/List";
 
 function StudentPage() {
-  const arr = new Array(10).fill({
-    title: "이태영",
-    group: "학생",
-    changeUserName: "김승원",
-    changeTime: "2424-08-28 08:37",
+  const { data, isLoading } = useQuery({
+    queryKey: ["recent-changes", "student"],
+    queryFn: () => fetchRecentChangesByCategory("student"),
   });
+
+  const rows =
+    data?.map(change => ({
+      id: change.id,
+      title: change.title,
+      group: wikiCategoryLabel(change.category),
+      changeUserName: change.editor,
+      changeTime: change.updatedAt,
+    })) ?? [];
+
   return (
     <div className="w-full flex justify-center">
       <div className="flex w-full max-w-screen-xl flex-col px-6 sm:px-4 lg:px-12">
@@ -52,15 +64,26 @@ function StudentPage() {
               changeUserName="변경자"
               changeTime="변경 시간"
             />
-            {arr.map(({ title, group, changeUserName, changeTime }, index) => (
-              <List
-                key={index}
-                title={title}
-                group={group}
-                changeUserName={changeUserName}
-                changeTime={changeTime}
-              />
-            ))}
+            {isLoading && (
+              <div className="border-b border-b-gray100 px-5 py-6 text-medium16 text-gray500 sm:px-4">
+                학생 문서를 불러오는 중입니다...
+              </div>
+            )}
+            {!isLoading && rows.length === 0 && (
+              <div className="border-b border-b-gray100 px-5 py-6 text-medium16 text-gray500 sm:px-4">
+                표시할 학생 문서가 없습니다.
+              </div>
+            )}
+            {!isLoading &&
+              rows.map(({ id, title, group, changeUserName, changeTime }) => (
+                <List
+                  key={id}
+                  title={title}
+                  group={group}
+                  changeUserName={changeUserName}
+                  changeTime={changeTime}
+                />
+              ))}
           </div>
           <Pagination />
         </div>

--- a/src/app/(with-header)/recent/page.tsx
+++ b/src/app/(with-header)/recent/page.tsx
@@ -1,16 +1,27 @@
-import React from "react";
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchRecentChanges, wikiCategoryLabel } from "@/apis";
 import { Title } from "../document/[id]/Title";
 import RecentList from "./List";
 import RecentPagination from "./Pagination";
 
 function Recent() {
-  const arr = Array.from({ length: 10 }, (_, index) => ({
-    id: `recent-${index + 1}`,
-    title: "이태영",
-    group: "학생",
-    changeUserName: "김승원",
-    changeTime: "2424-08-28 08:37",
-  }));
+  const { data, isLoading } = useQuery({
+    queryKey: ["recent-changes"],
+    queryFn: fetchRecentChanges,
+  });
+
+  const rows =
+    data?.map(change => ({
+      id: change.id,
+      title: change.title,
+      group: wikiCategoryLabel(change.category),
+      changeUserName: change.editor,
+      changeTime: change.updatedAt,
+    })) ?? [];
+
   return (
     <div className="w-full flex justify-center pb-12">
       <div className="flex w-full max-w-screen-xl flex-col gap-14 px-6 pt-16 sm:px-4 lg:px-12">
@@ -29,16 +40,27 @@ function Recent() {
             changeUserName="변경자"
             changeTime="변경 시간"
           />
-          {arr.map(({ id, title, group, changeUserName, changeTime }) => (
-            <RecentList
-              key={id}
-              listTitle={false}
-              title={title}
-              group={group}
-              changeUserName={changeUserName}
-              changeTime={changeTime}
-            />
-          ))}
+          {isLoading && (
+            <div className="border-b border-b-gray100 px-5 py-6 text-medium16 text-gray500 sm:px-4">
+              최근 변경을 불러오는 중입니다...
+            </div>
+          )}
+          {!isLoading && rows.length === 0 && (
+            <div className="border-b border-b-gray100 px-5 py-6 text-medium16 text-gray500 sm:px-4">
+              표시할 최근 변경 항목이 없습니다.
+            </div>
+          )}
+          {!isLoading &&
+            rows.map(({ id, title, group, changeUserName, changeTime }) => (
+              <RecentList
+                key={id}
+                listTitle={false}
+                title={title}
+                group={group}
+                changeUserName={changeUserName}
+                changeTime={changeTime}
+              />
+            ))}
         </div>
         <RecentPagination />
       </div>

--- a/src/interfaces/wiki.ts
+++ b/src/interfaces/wiki.ts
@@ -8,3 +8,17 @@ export interface WikiDocumentSummary {
   updatedAt: string;
   views: number;
 }
+
+export interface WikiRecentChange {
+  id: string;
+  title: string;
+  category: WikiCategory;
+  editor: string;
+  updatedAt: string;
+}
+
+export interface WikiDivisionCategory {
+  id: WikiCategory;
+  featured?: boolean;
+  route?: string;
+}


### PR DESCRIPTION
## Summary
- add wiki API contracts and mock fetchers for recent changes and division category data
- replace static lists in recent and division routes with React Query-backed data rendering
- keep loading/empty states aligned with existing page UI while preserving student category routing

Closes #22