### PR TITLE
[DMWCOMM-16] implement document intro edit/photo/api integration

### DIFF
--- a/src/apis/wiki.ts
+++ b/src/apis/wiki.ts
@@ -1,6 +1,7 @@
 import {
   WikiCategory,
   WikiDocumentDetail,
+  WikiDocumentProfileUpdateInput,
   WikiDivisionCategory,
   WikiDocumentSummary,
   WikiRecentChange,
@@ -185,6 +186,15 @@ const documentDetails: Record<string, WikiDocumentDetail> = {
   },
 };
 
+const cloneDocumentDetail = (
+  detail: WikiDocumentDetail,
+): WikiDocumentDetail => ({
+  ...detail,
+  profileInfo: detail.profileInfo.map(item => ({ ...item })),
+  sections: detail.sections.map(section => ({ ...section })),
+  relatedDocuments: [...detail.relatedDocuments],
+});
+
 const wait = <T>(value: T) =>
   new Promise<T>(resolve => {
     setTimeout(() => resolve(value), 120);
@@ -210,4 +220,50 @@ export const fetchDivisionCategories = async (): Promise<
 
 export const fetchWikiDocumentDetail = async (
   id: string,
-): Promise<WikiDocumentDetail | null> => wait(documentDetails[id] ?? null);
+): Promise<WikiDocumentDetail | null> => {
+  const detail = documentDetails[id];
+
+  return wait(detail ? cloneDocumentDetail(detail) : null);
+};
+
+export const updateWikiDocumentProfile = async (
+  id: string,
+  input: WikiDocumentProfileUpdateInput,
+): Promise<WikiDocumentDetail | null> => {
+  const current = documentDetails[id];
+
+  if (!current) {
+    return wait(null);
+  }
+
+  const nextDetail: WikiDocumentDetail = {
+    ...current,
+    badgeText: input.badgeText,
+    description: input.description,
+    profileInfo: input.profileInfo.map(item => ({ ...item })),
+  };
+
+  documentDetails[id] = nextDetail;
+
+  return wait(cloneDocumentDetail(nextDetail));
+};
+
+export const updateWikiDocumentPhoto = async (
+  id: string,
+  profileImageUrl: string,
+): Promise<WikiDocumentDetail | null> => {
+  const current = documentDetails[id];
+
+  if (!current) {
+    return wait(null);
+  }
+
+  const nextDetail: WikiDocumentDetail = {
+    ...current,
+    profileImageUrl,
+  };
+
+  documentDetails[id] = nextDetail;
+
+  return wait(cloneDocumentDetail(nextDetail));
+};

--- a/src/app/(with-header)/document/[id]/Profile.tsx
+++ b/src/app/(with-header)/document/[id]/Profile.tsx
@@ -1,38 +1,218 @@
-import React from "react";
-import { WikiDocumentInfoItem } from "@/interfaces/wiki";
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  WikiDocumentInfoItem,
+  WikiDocumentProfileUpdateInput,
+} from "@/interfaces/wiki";
 import InfoCardComponent from "./InfoCard";
 
 interface ProfileProps {
   badgeText?: string;
   description?: string;
   infoArr?: WikiDocumentInfoItem[];
+  profileImageUrl?: string;
+  canEdit?: boolean;
+  isSaving?: boolean;
+  onSave?: (input: WikiDocumentProfileUpdateInput) => void;
+  onUploadPhoto?: (profileImageUrl: string) => void;
 }
 
-function Profile({ badgeText, description, infoArr }: ProfileProps) {
-  const items = infoArr ?? [];
+function Profile({
+  badgeText,
+  description,
+  infoArr,
+  profileImageUrl,
+  canEdit,
+  isSaving,
+  onSave,
+  onUploadPhoto,
+}: ProfileProps) {
+  const items = useMemo(() => infoArr ?? [], [infoArr]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [draftBadgeText, setDraftBadgeText] = useState<string>(badgeText ?? "");
+  const [draftDescription, setDraftDescription] = useState<string>(
+    description ?? "",
+  );
+  const [draftInfoArr, setDraftInfoArr] =
+    useState<WikiDocumentInfoItem[]>(items);
+
+  useEffect(() => {
+    if (isEditing) {
+      return;
+    }
+
+    setDraftBadgeText(badgeText ?? "");
+    setDraftDescription(description ?? "");
+    setDraftInfoArr(items);
+  }, [badgeText, description, isEditing, items]);
+
+  const handleInfoChange = (index: number, text: string) => {
+    setDraftInfoArr(prev =>
+      prev.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, text } : item,
+      ),
+    );
+  };
+
+  const handleSave = () => {
+    onSave?.({
+      badgeText: draftBadgeText,
+      description: draftDescription,
+      profileInfo: draftInfoArr,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraftBadgeText(badgeText ?? "");
+    setDraftDescription(description ?? "");
+    setDraftInfoArr(items);
+    setIsEditing(false);
+  };
+
+  const handlePhotoClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handlePhotoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const { result } = reader;
+
+      if (typeof result === "string") {
+        onUploadPhoto?.(result);
+      }
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    };
+
+    reader.readAsDataURL(file);
+  };
 
   return (
     <div className="w-full flex flex-col gap-8 border-b border-gray200 px-6 py-8 sm:px-4 lg:px-12">
-      {/* Profile Section */}
-      <div className="w-full flex items-start gap-6">
+      <div className="w-full flex items-start gap-6 sm:flex-col">
         <div className="w-40 h-40 rounded-full border border-gray200 bg-gray100 overflow-hidden flex-shrink-0">
-          <div className="w-full h-full flex items-center justify-center text-gray400 text-medium16">
-            Profile
-          </div>
+          {profileImageUrl ? (
+            <div
+              className="w-full h-full bg-cover bg-center"
+              style={{ backgroundImage: `url(${profileImageUrl})` }}
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-gray400 text-medium16">
+              Profile
+            </div>
+          )}
         </div>
         <div className="flex flex-col gap-4 flex-1">
-          <div className="px-4 py-2 bg-lime50 rounded-lg w-fit">
-            <p className="text-lime500 text-semibold14">{badgeText}</p>
-          </div>
-          <p className="text-gray600 text-medium18">{description}</p>
+          {isEditing ? (
+            <input
+              value={draftBadgeText}
+              onChange={event => setDraftBadgeText(event.target.value)}
+              className="w-full max-w-[320px] rounded-lg border border-lime300 bg-lime50 px-4 py-2 text-semibold14 text-lime500"
+              placeholder="뱃지 텍스트"
+            />
+          ) : (
+            <div className="px-4 py-2 bg-lime50 rounded-lg w-fit">
+              <p className="text-lime500 text-semibold14">{badgeText}</p>
+            </div>
+          )}
+
+          {isEditing ? (
+            <textarea
+              value={draftDescription}
+              onChange={event => setDraftDescription(event.target.value)}
+              className="w-full rounded-lg border border-gray200 px-3 py-2 text-medium16 text-gray700"
+              rows={3}
+              placeholder="문서 소개 설명"
+            />
+          ) : (
+            <p className="text-gray600 text-medium18">{description}</p>
+          )}
+
+          {canEdit && (
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handlePhotoClick}
+                disabled={isSaving}
+                className="rounded-lg border border-gray200 bg-white px-4 py-2 text-medium14 text-gray700 hover:bg-gray50 disabled:opacity-60"
+              >
+                사진 추가
+              </button>
+
+              {!isEditing ? (
+                <button
+                  type="button"
+                  onClick={() => setIsEditing(true)}
+                  className="rounded-lg border border-lime300 bg-lime50 px-4 py-2 text-medium14 text-lime600 hover:bg-lime100"
+                >
+                  소개 수정
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    className="rounded-lg border border-gray200 bg-white px-4 py-2 text-medium14 text-gray700 hover:bg-gray50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    className="rounded-lg bg-lime500 px-4 py-2 text-medium14 text-white hover:bg-lime600 disabled:opacity-60"
+                  >
+                    저장
+                  </button>
+                </>
+              )}
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handlePhotoChange}
+                className="hidden"
+              />
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Metadata Grid */}
       <div className="grid grid-cols-6 gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {items.map(({ title, text }) => (
-          <InfoCardComponent title={title} text={text} key={title} />
-        ))}
+        {isEditing
+          ? draftInfoArr.map(({ title, text }, index) => (
+              <div
+                key={title}
+                className="flex flex-col gap-2 rounded-lg bg-gray50 p-4"
+              >
+                <span className="text-semibold14 text-lime500">{title}</span>
+                <input
+                  value={text}
+                  onChange={event =>
+                    handleInfoChange(index, event.target.value)
+                  }
+                  className="rounded-md border border-gray200 px-3 py-2 text-medium16 text-black"
+                />
+              </div>
+            ))
+          : items.map(({ title, text }) => (
+              <InfoCardComponent title={title} text={text} key={title} />
+            ))}
       </div>
     </div>
   );
@@ -46,6 +226,9 @@ Profile.defaultProps = {
   badgeText: "2113 이태영",
   description:
     "김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한 명입니다.",
+  profileImageUrl: "",
+  canEdit: false,
+  isSaving: false,
   infoArr: [
     { title: "학년", text: "3학년" },
     { title: "전공", text: "백엔드" },
@@ -54,4 +237,6 @@ Profile.defaultProps = {
     { title: "성별", text: "대장 갓이" },
     { title: "대마입학", text: "2007 / 11 / 03" },
   ],
+  onSave: undefined,
+  onUploadPhoto: undefined,
 };

--- a/src/app/(with-header)/document/[id]/page.tsx
+++ b/src/app/(with-header)/document/[id]/page.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import React, { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 
-import { fetchWikiDocumentDetail } from "@/apis";
-import { WikiDocumentDetail } from "@/interfaces/wiki";
+import {
+  fetchWikiDocumentDetail,
+  updateWikiDocumentPhoto,
+  updateWikiDocumentProfile,
+} from "@/apis";
+import {
+  WikiDocumentDetail,
+  WikiDocumentProfileUpdateInput,
+} from "@/interfaces/wiki";
 import { Sidebar } from "@/components";
 import { Bottom } from "./Bottom";
 import { Profile } from "./Profile";
@@ -17,6 +24,7 @@ const defaultDocument: WikiDocumentDetail = {
   title: "이태영",
   category: "student",
   views: 210,
+  profileImageUrl: "",
   badgeText: "2113 이태영",
   description:
     "김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한 명입니다.",
@@ -38,14 +46,65 @@ const defaultDocument: WikiDocumentDetail = {
 
 function Document() {
   const [openSidebar, setOpenSidebar] = useState<boolean>(true);
+  const queryClient = useQueryClient();
   const params = useParams<{ id: string }>();
   const rawId = params.id;
   const documentId = Array.isArray(rawId) ? rawId[0] : rawId;
+  const queryKey = ["wiki-document", documentId];
+
   const { data, isLoading } = useQuery<WikiDocumentDetail | null>({
-    queryKey: ["wiki-document", documentId],
-    queryFn: () => fetchWikiDocumentDetail(documentId),
+    queryKey,
+    queryFn: () => {
+      if (!documentId) {
+        return Promise.resolve(null);
+      }
+
+      return fetchWikiDocumentDetail(documentId);
+    },
     enabled: Boolean(documentId),
   });
+
+  const profileMutation = useMutation({
+    mutationFn: (input: WikiDocumentProfileUpdateInput) => {
+      if (!documentId) {
+        return Promise.resolve(null);
+      }
+
+      return updateWikiDocumentProfile(documentId, input);
+    },
+    onSuccess: updated => {
+      if (!updated) {
+        return;
+      }
+
+      queryClient.setQueryData(queryKey, updated);
+    },
+  });
+
+  const photoMutation = useMutation({
+    mutationFn: (profileImageUrl: string) => {
+      if (!documentId) {
+        return Promise.resolve(null);
+      }
+
+      return updateWikiDocumentPhoto(documentId, profileImageUrl);
+    },
+    onSuccess: updated => {
+      if (!updated) {
+        return;
+      }
+
+      queryClient.setQueryData(queryKey, updated);
+    },
+  });
+
+  const handleSaveProfile = (input: WikiDocumentProfileUpdateInput) => {
+    profileMutation.mutate(input);
+  };
+
+  const handleUploadPhoto = (profileImageUrl: string) => {
+    photoMutation.mutate(profileImageUrl);
+  };
 
   const documentData = data ?? defaultDocument;
   const contentsListArr = documentData.sections.map(({ num, title }) => ({
@@ -63,6 +122,11 @@ function Document() {
           badgeText={documentData.badgeText}
           description={documentData.description}
           infoArr={documentData.profileInfo}
+          profileImageUrl={documentData.profileImageUrl}
+          canEdit={Boolean(data)}
+          isSaving={profileMutation.isPending || photoMutation.isPending}
+          onSave={handleSaveProfile}
+          onUploadPhoto={handleUploadPhoto}
         />
         <div className="w-full px-6 py-6 sm:px-4 lg:px-12">
           {isLoading && (

--- a/src/interfaces/wiki.ts
+++ b/src/interfaces/wiki.ts
@@ -34,11 +34,18 @@ export interface WikiDocumentInfoItem {
   text: string;
 }
 
+export interface WikiDocumentProfileUpdateInput {
+  badgeText: string;
+  description: string;
+  profileInfo: WikiDocumentInfoItem[];
+}
+
 export interface WikiDocumentDetail {
   id: string;
   title: string;
   category: WikiCategory;
   views: number;
+  profileImageUrl?: string;
   badgeText: string;
   description: string;
   profileInfo: WikiDocumentInfoItem[];


### PR DESCRIPTION
## Summary
- add wiki profile update contracts and mock API mutations for intro text and profile photo
- convert the document intro profile card to support editing metadata and uploading a profile image
- wire `/document/[id]` with React Query mutations so intro edits persist in query cache

Closes #16