### PR TITLE
[DMWCOMM-135] replace non-semantic clickables with buttons

### DIFF
--- a/src/app/(with-header)/login/page.tsx
+++ b/src/app/(with-header)/login/page.tsx
@@ -45,12 +45,14 @@ export default function Login() {
   return (
     <div className="w-full h-screen flex justify-center pt-6">
       <div className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl">
-        <div
+        <button
+          type="button"
+          aria-label="뒤로 가기"
           onClick={() => router.back()}
           className="rounded-md w-fit border border-gray200 p-2 flex bg-white hover:bg-gray50"
         >
           <Arrow size={28} className="text-gray600" />
-        </div>
+        </button>
         <div className="w-full flex flex-col gap-6">
           <div className="w-full flex flex-col gap-3">
             <p className="text-bold36 text-black">로그인</p>
@@ -98,12 +100,13 @@ export default function Login() {
         <div className="w-full flex flex-col gap-6">
           <div className="flex gap-1.5">
             <p className="text-medium16 text-gray600">계정이 없으신가요?</p>
-            <p
+            <button
+              type="button"
               onClick={() => router.push("/signup")} // 회원가입으로 이동
               className="text-semibold16 text-lime500 hover:text-lime600 cursor-pointer"
             >
               회원가입
-            </p>
+            </button>
           </div>
           <Button onClick={handleLogin} big style="primary2" text="로그인" />{" "}
           {/* 로그인 핸들러 실행 */}

--- a/src/app/(with-header)/signup/page.tsx
+++ b/src/app/(with-header)/signup/page.tsx
@@ -143,12 +143,14 @@ export default function Signup() {
         className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl"
         onKeyDown={handleStepEnterSubmit}
       >
-        <div
+        <button
+          type="button"
+          aria-label="이전 단계"
           onClick={() => prevStep()}
           className="rounded-md w-fit border border-gray200 p-2 flex bg-white hover:bg-gray50"
         >
           <Arrow size={28} className="text-gray600" />
-        </div>
+        </button>
         <div className="w-full flex flex-col gap-6">
           <div className="w-full flex flex-col gap-3">
             <p className="text-bold36 text-black">회원가입</p>

--- a/src/components/RegisterInput.tsx
+++ b/src/components/RegisterInput.tsx
@@ -61,16 +61,18 @@ export const RegisterInput = ({
       </div>
     ),
     password: (
-      <div
+      <button
+        type="button"
+        aria-label="비밀번호 표시 전환"
         onClick={() => setHidePassword(!hidePassword)}
         className="flex p-3 cursor-pointer text-gray500"
       >
         {hidePassword ? <Hide /> : <Show />}
-      </div>
+      </button>
     ),
     text: <></>,
     dropdown: (
-      <div className="p-3 flex cursor-pointer">
+      <div className="p-3 flex">
         <Arrow
           className="text-gray600 transition-all"
           direction={dropdownOpen ? "up" : "down"}
@@ -85,15 +87,21 @@ export const RegisterInput = ({
         <div className="w-full px-3 pt-3 flex text-gray600 text-semibold16">
           {title}
         </div>
-        <div
-          onClick={() => type === "dropdown" && setDropdownOpen(!dropdownOpen)}
-          className="gap-2 flex w-full items-center"
-        >
-          {type === "dropdown" ? (
-            <div className="w-full cursor-pointer flex p-3 text-medium20 text-gray800">
+        {type === "dropdown" ? (
+          <button
+            type="button"
+            onClick={() => setDropdownOpen(prev => !prev)}
+            aria-haspopup="listbox"
+            aria-expanded={dropdownOpen}
+            className="gap-2 flex w-full items-center"
+          >
+            <span className="w-full flex p-3 text-medium20 text-gray800 text-left">
               {value || placeholder}
-            </div>
-          ) : (
+            </span>
+            {inputType[type]}
+          </button>
+        ) : (
+          <div className="gap-2 flex w-full items-center">
             <input
               autoFocus={autoFocus}
               value={value}
@@ -102,27 +110,33 @@ export const RegisterInput = ({
               placeholder={placeholder}
               className="w-full p-3 placeholder:text-gray300 text-medium20"
             />
-          )}
-          {inputType[type]}
-        </div>
+            {inputType[type]}
+          </div>
+        )}
       </div>
 
-      <p className="text-medium14 text-red500 relative">
+      <div className="text-medium14 text-red500 relative">
         {error}
         {type === "dropdown" && dropdownOpen && (
-          <div className="top-0 z-10 rounded-lg bg-white border border-gray200 shadow-lg overflow-y-scroll absolute w-[432px] h-36 flex flex-col">
+          <div
+            role="listbox"
+            className="top-0 z-10 rounded-lg bg-white border border-gray200 shadow-lg overflow-y-scroll absolute w-[432px] h-36 flex flex-col"
+          >
             {dropdownValue?.map((item, index) => (
-              <div
+              <button
+                type="button"
                 key={index}
                 onClick={() => handleDropdownChange(item)}
+                role="option"
+                aria-selected={String(value) === String(item)}
                 className="w-full py-3 px-4 border-b border-b-gray100 text-black text-medium18 hover:bg-gray50"
               >
                 {item}
-              </div>
+              </button>
             ))}
           </div>
         )}
-      </p>
+      </div>
     </div>
   );
 };

--- a/src/components/table/modal.tsx
+++ b/src/components/table/modal.tsx
@@ -23,15 +23,27 @@ const TableModal = ({ state, setState, close }: TableModalProps) => {
   }, []);
   return (
     <div className="flex flex-col border-[1px]" ref={moreRef}>
-      <div className="px-2" onClick={() => setState("add")}>
+      <button
+        type="button"
+        className="px-2 text-left"
+        onClick={() => setState("add")}
+      >
         <span>추가</span>
-      </div>
-      <div className="border-t-[1px] px-2" onClick={() => setState("edit")}>
+      </button>
+      <button
+        type="button"
+        className="border-t-[1px] px-2 text-left"
+        onClick={() => setState("edit")}
+      >
         <span>수정</span>
-      </div>
-      <div className="border-t-[1px] px-2" onClick={() => setState("del")}>
+      </button>
+      <button
+        type="button"
+        className="border-t-[1px] px-2 text-left"
+        onClick={() => setState("del")}
+      >
         <span className="text-[#ff0000]">삭제</span>
-      </div>
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- convert clickable non-semantic controls in login/signup screens to semantic `button` elements
- improve shared `RegisterInput` and table modal controls to use keyboard-focusable button interactions with ARIA attributes
- add accessibility metadata for icon/toggle controls to align with keyboard and screen-reader expectations

## Verification
- `lsp_diagnostics` on changed files: clean
- `yarn tsc --noEmit`: fails due to pre-existing baseline type errors in unrelated files
- `yarn lint --file ...`: fails due to baseline missing eslint config dependency (`airbnb`)

Closes #135