### PR TITLE
fix: improve RegisterInput dropdown keyboard and ARIA behavior

### DIFF
--- a/src/components/RegisterInput.tsx
+++ b/src/components/RegisterInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Arrow, Hide, Show } from "@/assets";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useId } from "react";
 
 interface InputProps {
   title?: string;
@@ -25,14 +25,143 @@ export const RegisterInput = ({
 }: InputProps) => {
   const [hidePassword, setHidePassword] = useState<boolean>(true); // 비밀번호 숨기기
   const [dropdownOpen, setDropdownOpen] = useState<boolean>(false); // 드롭다운 열기
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const [announcement, setAnnouncement] = useState<string>("");
   const inputRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const controlId = useId();
+
+  const labelId = `register-input-label-${controlId}`;
+  const listboxId = `register-input-listbox-${controlId}`;
+
+  const dropdownItems = dropdownValue ?? [];
+  const selectedIndex = dropdownItems.findIndex(
+    item => String(item) === String(value),
+  );
+
+  const focusOption = (index: number) => {
+    const boundedIndex = Math.max(0, Math.min(index, dropdownItems.length - 1));
+    optionRefs.current[boundedIndex]?.focus();
+    setActiveIndex(boundedIndex);
+  };
+
+  const openDropdown = (initialIndex?: number) => {
+    if (!dropdownItems.length) {
+      return;
+    }
+
+    const nextIndex =
+      typeof initialIndex === "number"
+        ? initialIndex
+        : selectedIndex >= 0
+          ? selectedIndex
+          : 0;
+
+    setDropdownOpen(true);
+    setActiveIndex(nextIndex);
+    setAnnouncement("옵션 목록이 열렸습니다.");
+  };
+
+  const closeDropdown = () => {
+    setDropdownOpen(false);
+    setActiveIndex(-1);
+    setAnnouncement("옵션 목록이 닫혔습니다.");
+  };
 
   // 드롭다운에서 선택한 값을 업데이트하는 함수
   const handleDropdownChange = (item: string | number) => {
     if (onChange) {
       onChange(item); // 선택된 값을 직접 전달
     }
-    setDropdownOpen(false); // 드롭다운 닫기
+    setAnnouncement(`${item}이(가) 선택되었습니다.`);
+    closeDropdown();
+    triggerRef.current?.focus();
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!dropdownItems.length) {
+      return;
+    }
+
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (dropdownOpen) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!dropdownOpen) {
+        openDropdown(selectedIndex >= 0 ? selectedIndex : 0);
+        return;
+      }
+      focusOption(activeIndex + 1);
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!dropdownOpen) {
+        openDropdown(
+          selectedIndex >= 0 ? selectedIndex : dropdownItems.length - 1,
+        );
+        return;
+      }
+      focusOption(activeIndex - 1);
+      return;
+    }
+
+    if (e.key === "Escape" && dropdownOpen) {
+      e.preventDefault();
+      closeDropdown();
+    }
+  };
+
+  const handleOptionKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+    item: string | number,
+  ) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      focusOption(index + 1);
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      focusOption(index - 1);
+      return;
+    }
+
+    if (e.key === "Home") {
+      e.preventDefault();
+      focusOption(0);
+      return;
+    }
+
+    if (e.key === "End") {
+      e.preventDefault();
+      focusOption(dropdownItems.length - 1);
+      return;
+    }
+
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleDropdownChange(item);
+      return;
+    }
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeDropdown();
+      triggerRef.current?.focus();
+    }
   };
 
   // 외부 클릭 시 드롭다운 닫기
@@ -42,7 +171,7 @@ export const RegisterInput = ({
         inputRef.current &&
         !inputRef.current.contains(event.target as Node)
       ) {
-        setDropdownOpen(false);
+        closeDropdown();
       }
     };
 
@@ -51,6 +180,16 @@ export const RegisterInput = ({
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
+
+  useEffect(() => {
+    if (!dropdownOpen) {
+      return;
+    }
+
+    const nextIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    setActiveIndex(nextIndex);
+    optionRefs.current[nextIndex]?.focus();
+  }, [dropdownOpen, selectedIndex]);
 
   const inputType = {
     email: (
@@ -64,6 +203,7 @@ export const RegisterInput = ({
       <button
         type="button"
         aria-label="비밀번호 표시 전환"
+        aria-pressed={!hidePassword}
         onClick={() => setHidePassword(!hidePassword)}
         className="flex p-3 cursor-pointer text-gray500"
       >
@@ -85,14 +225,30 @@ export const RegisterInput = ({
     <div className="flex flex-col w-full gap-2" ref={inputRef}>
       <div className="rounded-lg focus-within:border-lime500 overflow-hidden flex flex-col w-full border border-gray200">
         <div className="w-full px-3 pt-3 flex text-gray600 text-semibold16">
-          {title}
+          <span id={labelId}>{title}</span>
         </div>
         {type === "dropdown" ? (
           <button
+            ref={triggerRef}
             type="button"
-            onClick={() => setDropdownOpen(prev => !prev)}
+            onClick={() => {
+              if (dropdownOpen) {
+                closeDropdown();
+              } else {
+                openDropdown();
+              }
+            }}
+            onKeyDown={handleTriggerKeyDown}
+            role="combobox"
+            aria-labelledby={labelId}
             aria-haspopup="listbox"
             aria-expanded={dropdownOpen}
+            aria-controls={listboxId}
+            aria-activedescendant={
+              dropdownOpen && activeIndex >= 0
+                ? `${listboxId}-option-${activeIndex}`
+                : undefined
+            }
             className="gap-2 flex w-full items-center"
           >
             <span className="w-full flex p-3 text-medium20 text-gray800 text-left">
@@ -119,23 +275,34 @@ export const RegisterInput = ({
         {error}
         {type === "dropdown" && dropdownOpen && (
           <div
+            id={listboxId}
             role="listbox"
+            aria-labelledby={labelId}
             className="top-0 z-10 rounded-lg bg-white border border-gray200 shadow-lg overflow-y-scroll absolute w-[432px] h-36 flex flex-col"
           >
-            {dropdownValue?.map((item, index) => (
+            {dropdownItems.map((item, index) => (
               <button
                 type="button"
+                ref={element => {
+                  optionRefs.current[index] = element;
+                }}
                 key={index}
                 onClick={() => handleDropdownChange(item)}
+                onKeyDown={e => handleOptionKeyDown(e, index, item)}
+                onFocus={() => setActiveIndex(index)}
+                id={`${listboxId}-option-${index}`}
                 role="option"
                 aria-selected={String(value) === String(item)}
-                className="w-full py-3 px-4 border-b border-b-gray100 text-black text-medium18 hover:bg-gray50"
+                className="w-full py-3 px-4 border-b border-b-gray100 text-black text-medium18 hover:bg-gray50 text-left"
               >
                 {item}
               </button>
             ))}
           </div>
         )}
+      </div>
+      <div className="sr-only" aria-live="polite">
+        {announcement}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add combobox/listbox ARIA wiring for RegisterInput dropdown trigger and options (`aria-controls`, `aria-activedescendant`, selected state)
- implement keyboard interactions (Enter/Space/Arrow/Home/End/Escape) for opening, navigating, selecting, and closing dropdown options
- improve screen-reader feedback with polite live announcements and add `aria-pressed` on password visibility toggle

## Validation
- `lsp_diagnostics` clean on `src/components/RegisterInput.tsx`
- `yarn tsc --noEmit` (fails due to pre-existing unrelated type errors)
- `yarn lint` (fails due to pre-existing missing ESLint config dependency: `airbnb`)

Closes #137