### PR TITLE
fix: apply container auth shell layout for login/signup

### DIFF
--- a/src/app/(with-header)/login/page.tsx
+++ b/src/app/(with-header)/login/page.tsx
@@ -43,8 +43,8 @@ export default function Login() {
   });
 
   return (
-    <div className="w-full h-screen flex justify-center pt-6">
-      <div className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl">
+    <div className="w-full flex justify-center px-4 py-8 md:py-6 sm:py-4">
+      <div className="w-full max-w-[520px] flex flex-col gap-10 rounded-3xl border border-gray200 bg-white p-6 shadow-sm md:p-5 sm:p-4">
         <button
           type="button"
           aria-label="뒤로 가기"
@@ -97,7 +97,7 @@ export default function Login() {
             />
           </div>
         </div>
-        <div className="w-full flex flex-col gap-6">
+        <div className="w-full flex flex-col gap-5">
           <div className="flex gap-1.5">
             <p className="text-medium16 text-gray600">계정이 없으신가요?</p>
             <button

--- a/src/app/(with-header)/signup/page.tsx
+++ b/src/app/(with-header)/signup/page.tsx
@@ -138,9 +138,9 @@ export default function Signup() {
   };
 
   return (
-    <div className="w-full h-screen flex justify-center pt-6">
+    <div className="w-full flex justify-center px-4 py-8 md:py-6 sm:py-4">
       <div
-        className="w-[480px] flex flex-col gap-12 p-6 rounded-3xl"
+        className="w-full max-w-[520px] flex flex-col gap-10 rounded-3xl border border-gray200 bg-white p-6 shadow-sm md:p-5 sm:p-4"
         onKeyDown={handleStepEnterSubmit}
       >
         <button
@@ -160,7 +160,7 @@ export default function Signup() {
           </div>
           {page[pageNum].page}
         </div>
-        <div className="w-full flex flex-col gap-6">
+        <div className="w-full flex flex-col gap-5">
           <div className="w-full gap-2 flex justify-center items-center">
             {page.map((_, index) => (
               <div


### PR DESCRIPTION
## Summary
- replace full-height auth panels with shared max-width container shells on login/signup pages
- align spacing tokens and panel chrome (border, radius, padding) so title/content/CTA hierarchy stays consistent
- reduce visual collision with the global header by using balanced top/bottom page padding on desktop and mobile

## Validation
- `lsp_diagnostics` clean on `src/app/(with-header)/login/page.tsx`
- `lsp_diagnostics` clean on `src/app/(with-header)/signup/page.tsx`
- `yarn tsc --noEmit` blocked in this worktree by Yarn workspace lock/install state (`daemawiki@workspace:.` missing in lockfile)

Closes #132