### PR TITLE
fix: complete legacy header routing and search interactions

### DIFF
--- a/src/app/(with-header)/mypage/page.tsx
+++ b/src/app/(with-header)/mypage/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+
+export default function MyPage() {
+  return (
+    <div className="w-full flex justify-center pb-12">
+      <div className="w-full pt-16 px-12 max-w-[1200px] flex flex-col gap-8">
+        <section className="flex flex-col gap-3">
+          <h1 className="text-bold36 text-black">마이페이지</h1>
+          <p className="text-medium18 text-gray500">
+            내 활동과 계정 정보를 확인할 수 있는 페이지입니다.
+          </p>
+        </section>
+
+        <div className="rounded-2xl border border-gray200 bg-white p-8 flex flex-col gap-3">
+          <p className="text-semibold20 text-gray800">준비 중입니다.</p>
+          <p className="text-medium16 text-gray500">
+            곧 내 문서 기여 내역과 프로필 관리 기능이 제공됩니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/search/page.tsx
+++ b/src/app/(with-header)/search/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface SearchItem {
+  id: string;
+  title: string;
+  group: string;
+  content: string;
+}
+
+const searchSource: SearchItem[] = [
+  {
+    id: "1",
+    title: "이태영",
+    group: "학생",
+    content: "1학년 4반의 오타쿠 이태영.",
+  },
+  {
+    id: "2",
+    title: "김승원",
+    group: "학생",
+    content: "대마위키를 운영하는 개발자 멤버입니다.",
+  },
+  {
+    id: "3",
+    title: "대마위키",
+    group: "프로젝트",
+    content: "대덕소프트웨어마이스터고 학생 위키 서비스입니다.",
+  },
+];
+
+export default function SearchPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const query = searchParams.get("q") ?? "";
+  const [keyword, setKeyword] = useState<string>(query);
+
+  useEffect(() => {
+    setKeyword(query);
+  }, [query]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const searchedList = useMemo(() => {
+    if (!normalizedQuery) {
+      return [];
+    }
+
+    return searchSource.filter(item => {
+      const title = item.title.toLowerCase();
+      const content = item.content.toLowerCase();
+
+      return (
+        title.includes(normalizedQuery) || content.includes(normalizedQuery)
+      );
+    });
+  }, [normalizedQuery]);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedKeyword = keyword.trim();
+
+    if (!trimmedKeyword) {
+      router.push("/search");
+      return;
+    }
+
+    router.push(`/search?q=${encodeURIComponent(trimmedKeyword)}`);
+  };
+
+  return (
+    <div className="w-full flex justify-center pb-12">
+      <div className="w-full pt-16 px-12 max-w-[1200px] flex flex-col gap-10">
+        <section className="flex flex-col gap-3">
+          <h1 className="text-bold36 text-black">문서 검색</h1>
+          <p className="text-medium18 text-gray500">
+            제목과 내용으로 문서를 검색할 수 있습니다.
+          </p>
+        </section>
+
+        <form
+          onSubmit={onSubmit}
+          className="flex gap-3 md:flex-col sm:flex-col"
+        >
+          <input
+            value={keyword}
+            onChange={event => setKeyword(event.target.value)}
+            placeholder="검색어를 입력하세요"
+            className="w-full rounded-lg border border-gray200 px-4 py-3 text-medium16 text-black placeholder:text-gray400"
+          />
+          <button
+            type="submit"
+            className="rounded-lg bg-lime500 px-6 py-3 text-semibold16 text-white hover:bg-lime600 transition-all"
+          >
+            검색
+          </button>
+        </form>
+
+        {normalizedQuery ? (
+          <div className="flex flex-col gap-3">
+            {searchedList.length > 0 ? (
+              searchedList.map(item => (
+                <button
+                  type="button"
+                  key={item.id}
+                  onClick={() => router.push(`/document/${item.id}`)}
+                  className="w-full rounded-xl border border-gray200 bg-white p-5 text-left hover:border-lime300 transition-all"
+                >
+                  <p className="text-semibold20 text-black">{item.title}</p>
+                  <p className="pt-2 text-medium14 text-gray500">
+                    {item.group}
+                  </p>
+                  <p className="pt-3 text-medium16 text-gray600">
+                    {item.content}
+                  </p>
+                </button>
+              ))
+            ) : (
+              <div className="rounded-xl border border-gray200 bg-white p-8 text-center text-medium16 text-gray500">
+                검색 결과가 없습니다.
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-gray200 bg-white p-8 text-center text-medium16 text-gray500">
+            검색어를 입력하면 결과가 표시됩니다.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,33 +5,65 @@ import { Button, SearchInput } from "@/components";
 import { usePathname, useRouter } from "next/navigation";
 import { getCookie } from "@/apis/cookies";
 
+interface NavItem {
+  text: string;
+  link: string;
+  priority: number;
+  subItems?: {
+    text: string;
+    link: string;
+  }[];
+}
+
 export const Header = () => {
   const router = useRouter();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
+  const [searchKeyword, setSearchKeyword] = useState<string>("");
   const mobileMenuRef = useRef<HTMLDivElement>(null);
 
-  const navList = [
+  const navList: NavItem[] = [
     {
       text: "분류",
       link: "/division",
-      array: ["학생", "선생님", "사건/사고", "동아리"],
+      subItems: [
+        { text: "학생", link: "/division/student" },
+        { text: "선생님", link: "/division" },
+        { text: "사건/사고", link: "/division" },
+        { text: "동아리", link: "/division" },
+      ],
       priority: 1,
     },
     {
-      text: "게시판",
-      link: "/",
-      array: ["학생", "선생님", "어쩌고"],
+      text: "인기문서",
+      link: "/popular",
       priority: 2,
     },
-    { text: "최근변경", link: "/recent", array: [""], priority: 3 },
-    { text: "팀소개", link: "/team", array: [""], priority: 4 },
+    { text: "최근변경", link: "/recent", priority: 3 },
+    { text: "랜덤문서", link: "/document/1", priority: 4 },
+    { text: "팀소개", link: "/team", priority: 5 },
   ];
 
   const primaryMobileNav = navList
     .filter(item => item.priority <= 3)
     .sort((a, b) => a.priority - b.priority);
   const secondaryMobileNav = navList.filter(item => item.priority > 3);
+
+  const routeTo = (link: string) => {
+    router.push(link);
+    setMobileMenuOpen(false);
+  };
+
+  const submitSearch = () => {
+    const trimmedKeyword = searchKeyword.trim();
+
+    if (!trimmedKeyword) {
+      router.push("/search");
+      return;
+    }
+
+    router.push(`/search?q=${encodeURIComponent(trimmedKeyword)}`);
+  };
 
   const isActive = (link: string) => {
     if (link === "/") {
@@ -82,14 +114,14 @@ export const Header = () => {
               </div>
             </div>
             <div className="hidden lg:flex items-center gap-1 flex-none">
-              {navList.map(({ text, array, link }, index) => (
+              {navList.map(({ text, link, subItems }, index) => (
                 <div
                   key={index}
                   className="flex relative items-center justify-center min-h-[44px] group"
                 >
                   <button
                     type="button"
-                    onClick={() => router.push(link)}
+                    onClick={() => routeTo(link)}
                     aria-current={isActive(link) ? "page" : undefined}
                     className={`flex items-center gap-0.5 rounded-md px-3 py-2 transition-all ${
                       isActive(link)
@@ -98,7 +130,7 @@ export const Header = () => {
                     }`}
                   >
                     <p className="text-semibold18">{text}</p>
-                    {array.length > 1 && (
+                    {subItems && subItems.length > 0 && (
                       <Arrow
                         direction="down"
                         className={
@@ -109,14 +141,17 @@ export const Header = () => {
                       />
                     )}
                   </button>
-                  {array.length > 1 && (
+                  {subItems && subItems.length > 0 && (
                     <ul className="flex flex-col group-hover:left-0 group-focus-within:left-0 absolute top-11 rounded-lg -left-[9999px] min-w-[120px] shadow-lg bg-white overflow-hidden border border-gray200">
-                      {array.map((item, itemIndex) => (
-                        <li
-                          key={itemIndex}
-                          className="w-full px-4 py-2 bg-white hover:bg-gray50 whitespace-nowrap text-medium16 text-gray700"
-                        >
-                          {item}
+                      {subItems.map((item, itemIndex) => (
+                        <li key={itemIndex} className="w-full">
+                          <button
+                            type="button"
+                            onClick={() => routeTo(item.link)}
+                            className="w-full px-4 py-2 bg-white hover:bg-gray50 whitespace-nowrap text-medium16 text-gray700 text-left"
+                          >
+                            {item.text}
+                          </button>
                         </li>
                       ))}
                     </ul>
@@ -127,10 +162,21 @@ export const Header = () => {
           </div>
           <div className="flex items-center lg:gap-10 gap-4">
             <div className="w-[240px] flex md:hidden sm:hidden">
-              <SearchInput placeholder="검색" />
+              <SearchInput
+                placeholder="검색"
+                value={searchKeyword}
+                onChange={setSearchKeyword}
+                onSubmit={submitSearch}
+              />
             </div>
             {access_token ? (
-              <div></div>
+              <div className="flex md:hidden sm:hidden items-center gap-2">
+                <Button
+                  onClick={() => routeTo("/mypage")}
+                  text="마이페이지"
+                  style="white"
+                />
+              </div>
             ) : (
               <>
                 <div className="flex md:hidden sm:hidden items-center gap-2">
@@ -147,7 +193,7 @@ export const Header = () => {
                 </div>
                 <button
                   type="button"
-                  onClick={() => router.push("/login")}
+                  onClick={() => routeTo(access_token ? "/mypage" : "/login")}
                   className="hidden md:flex sm:flex p-1 cursor-pointer min-h-[44px] min-w-[44px] items-center justify-center"
                 >
                   <User className="text-gray500" />
@@ -158,12 +204,13 @@ export const Header = () => {
         </div>
       </div>
 
-      <div className="hidden md:flex sm:flex px-6 items-center">
-        <input
+      <div className="hidden md:flex sm:flex px-6 py-2 items-center">
+        <SearchInput
           placeholder="여기에서 검색"
-          className="text-black placeholder:text-gray400 bg-transparent text-medium16 w-full py-2"
+          value={searchKeyword}
+          onChange={setSearchKeyword}
+          onSubmit={submitSearch}
         />
-        <Arrow direction="right" className="text-gray300" />
       </div>
 
       <div className="hidden md:flex sm:flex px-4 py-2 border-t border-gray200 items-center gap-2">
@@ -171,7 +218,7 @@ export const Header = () => {
           <button
             type="button"
             key={item.text}
-            onClick={() => router.push(item.link)}
+            onClick={() => routeTo(item.link)}
             aria-current={isActive(item.link) ? "page" : undefined}
             className={`flex-1 min-h-[44px] rounded-md px-2 text-medium16 text-center ${
               isActive(item.link)
@@ -200,10 +247,7 @@ export const Header = () => {
                   <button
                     type="button"
                     key={item.text}
-                    onClick={() => {
-                      router.push(item.link);
-                      setMobileMenuOpen(false);
-                    }}
+                    onClick={() => routeTo(item.link)}
                     className={`w-full min-h-[44px] px-4 text-left text-medium16 ${
                       isActive(item.link)
                         ? "bg-lime100 text-lime500"


### PR DESCRIPTION
## Summary
- wire header navigation for division/popular/recent/random/team routes and align desktop/mobile quick actions
- connect header search inputs to `/search` query routing so title/content searches are reachable from header interactions
- add base `/search` and `/mypage` route screens so new header routes resolve without dead links

## Validation
- `lsp_diagnostics` clean on:
  - `src/components/Header.tsx`
  - `src/app/(with-header)/search/page.tsx`
  - `src/app/(with-header)/mypage/page.tsx`
- `yarn tsc --noEmit` blocked in this worktree by Yarn workspace lock state (`daemawiki@workspace:.` missing in lockfile)

Closes #1