### PR TITLE
feat: finish legacy sidebar responsiveness and quick links

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,2 +1,3 @@
 export * from "./user";
 export * from "./mail";
+export * from "./sidebar";

--- a/src/apis/sidebar.ts
+++ b/src/apis/sidebar.ts
@@ -1,0 +1,30 @@
+export interface SidebarDocumentItem {
+  id: string;
+  title: string;
+  minutesAgo: number;
+  views: number;
+}
+
+const sidebarDocuments: SidebarDocumentItem[] = [
+  { id: "1", title: "이태영", minutesAgo: 8, views: 7942 },
+  { id: "2", title: "김승원", minutesAgo: 12, views: 6974 },
+  { id: "3", title: "김어진", minutesAgo: 18, views: 5948 },
+  { id: "4", title: "박지민", minutesAgo: 24, views: 5877 },
+  { id: "5", title: "팀 DM", minutesAgo: 39, views: 4485 },
+  { id: "6", title: "최선생", minutesAgo: 47, views: 1592 },
+  { id: "7", title: "해커톤 빌드 실패", minutesAgo: 65, views: 1004 },
+  { id: "8", title: "대마위키", minutesAgo: 78, views: 54 },
+  { id: "9", title: "랜덤 문서 예시", minutesAgo: 92, views: 32 },
+  { id: "10", title: "문서 편집 가이드", minutesAgo: 120, views: 3 },
+];
+
+const wait = <T>(value: T) =>
+  new Promise<T>(resolve => {
+    setTimeout(() => resolve(value), 140);
+  });
+
+export const fetchSidebarRecentDocuments = async () =>
+  wait([...sidebarDocuments].sort((a, b) => a.minutesAgo - b.minutesAgo));
+
+export const fetchSidebarPopularDocuments = async () =>
+  wait([...sidebarDocuments].sort((a, b) => b.views - a.views));

--- a/src/app/(with-header)/main/page.tsx
+++ b/src/app/(with-header)/main/page.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components";
 import { IndexItem, mainPageIndex } from "@/constant/indexItem";
+import SideBar from "@/components/sideBar/sideBar";
 
 type LoadStatus = "loading" | "success" | "empty" | "error";
 
@@ -43,77 +44,83 @@ function Main() {
 
   return (
     <section className="w-full min-h-[calc(100dvh-160px)] bg-gray50 px-4 py-8 md:py-6 sm:py-4">
-      <div className="mx-auto w-full max-w-[980px] flex flex-col gap-4">
-        <div className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4">
-          <h1 className="text-bold32 text-black md:text-bold28 sm:text-bold24">
-            대마위키 온보딩
-          </h1>
-          <p className="mt-2 text-medium16 text-gray600">
-            처음 방문한 사용자를 위한 안내 문서를 빠르게 확인하세요.
-          </p>
+      <div className="mx-auto flex w-full max-w-[1320px] gap-6 md:flex-col sm:flex-col">
+        <div className="flex w-full max-w-[980px] flex-col gap-4">
+          <div className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4">
+            <h1 className="text-bold32 text-black md:text-bold28 sm:text-bold24">
+              대마위키 온보딩
+            </h1>
+            <p className="mt-2 text-medium16 text-gray600">
+              처음 방문한 사용자를 위한 안내 문서를 빠르게 확인하세요.
+            </p>
+          </div>
+
+          {status === "loading" && (
+            <div className="flex flex-col gap-3">
+              {[0, 1, 2].map(index => (
+                <div
+                  key={index}
+                  className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4"
+                >
+                  <div className="h-6 w-32 rounded bg-gray100 animate-pulse" />
+                  <div className="mt-3 h-4 w-full rounded bg-gray100 animate-pulse" />
+                  <div className="mt-2 h-4 w-3/4 rounded bg-gray100 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {status === "error" && (
+            <div className="rounded-2xl border border-red200 bg-white p-6 md:p-5 sm:p-4 flex flex-col gap-4">
+              <p className="text-semibold20 text-red500">불러오기 실패</p>
+              <p className="text-medium16 text-gray700">{errorMessage}</p>
+              <div className="w-fit">
+                <Button onClick={loadMain} style="primary2" text="다시 시도" />
+              </div>
+            </div>
+          )}
+
+          {status === "empty" && (
+            <div className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4 flex flex-col gap-4">
+              <p className="text-semibold20 text-gray800">
+                표시할 온보딩 문서가 없습니다.
+              </p>
+              <p className="text-medium16 text-gray600">
+                잠시 후 다시 시도하거나 관리자에게 상태를 문의해주세요.
+              </p>
+              <div className="w-fit">
+                <Button onClick={loadMain} style="white" text="새로고침" />
+              </div>
+            </div>
+          )}
+
+          {status === "success" && (
+            <div className="flex flex-col gap-3">
+              {sections.map(section => (
+                <article
+                  key={section.index}
+                  className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex min-h-[28px] min-w-[28px] items-center justify-center rounded-full bg-lime100 px-2 text-semibold14 text-lime500">
+                      {section.index}
+                    </span>
+                    <h2 className="text-semibold24 text-gray900 md:text-semibold20 sm:text-semibold18">
+                      {section.title}
+                    </h2>
+                  </div>
+                  <p className="mt-3 whitespace-pre-line text-medium16 text-gray700">
+                    {section.detail}
+                  </p>
+                </article>
+              ))}
+            </div>
+          )}
         </div>
 
-        {status === "loading" && (
-          <div className="flex flex-col gap-3">
-            {[0, 1, 2].map(index => (
-              <div
-                key={index}
-                className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4"
-              >
-                <div className="h-6 w-32 rounded bg-gray100 animate-pulse" />
-                <div className="mt-3 h-4 w-full rounded bg-gray100 animate-pulse" />
-                <div className="mt-2 h-4 w-3/4 rounded bg-gray100 animate-pulse" />
-              </div>
-            ))}
-          </div>
-        )}
-
-        {status === "error" && (
-          <div className="rounded-2xl border border-red200 bg-white p-6 md:p-5 sm:p-4 flex flex-col gap-4">
-            <p className="text-semibold20 text-red500">불러오기 실패</p>
-            <p className="text-medium16 text-gray700">{errorMessage}</p>
-            <div className="w-fit">
-              <Button onClick={loadMain} style="primary2" text="다시 시도" />
-            </div>
-          </div>
-        )}
-
-        {status === "empty" && (
-          <div className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4 flex flex-col gap-4">
-            <p className="text-semibold20 text-gray800">
-              표시할 온보딩 문서가 없습니다.
-            </p>
-            <p className="text-medium16 text-gray600">
-              잠시 후 다시 시도하거나 관리자에게 상태를 문의해주세요.
-            </p>
-            <div className="w-fit">
-              <Button onClick={loadMain} style="white" text="새로고침" />
-            </div>
-          </div>
-        )}
-
-        {status === "success" && (
-          <div className="flex flex-col gap-3">
-            {sections.map(section => (
-              <article
-                key={section.index}
-                className="rounded-2xl border border-gray200 bg-white p-6 md:p-5 sm:p-4"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="inline-flex min-h-[28px] min-w-[28px] items-center justify-center rounded-full bg-lime100 px-2 text-semibold14 text-lime500">
-                    {section.index}
-                  </span>
-                  <h2 className="text-semibold24 text-gray900 md:text-semibold20 sm:text-semibold18">
-                    {section.title}
-                  </h2>
-                </div>
-                <p className="mt-3 whitespace-pre-line text-medium16 text-gray700">
-                  {section.detail}
-                </p>
-              </article>
-            ))}
-          </div>
-        )}
+        <div className="w-full max-w-[320px] md:max-w-none sm:max-w-none">
+          <SideBar />
+        </div>
       </div>
     </section>
   );

--- a/src/components/sideBar/documentPreview.tsx
+++ b/src/components/sideBar/documentPreview.tsx
@@ -1,20 +1,34 @@
+import Link from "next/link";
+
 interface DocumentType {
+  documentId: string;
   documentName: string;
-  time: number;
+  minutesAgo: number;
   views: number;
 }
 
-const DocumentPreview = ({ documentName: name, time, views }: DocumentType) => {
+const DocumentPreview = ({
+  documentId,
+  documentName: name,
+  minutesAgo,
+  views,
+}: DocumentType) => {
+  const timeLabel =
+    minutesAgo < 60
+      ? `${minutesAgo}분 전`
+      : `${Math.floor(minutesAgo / 60)}시간 전`;
+
   return (
-    <div className="flex px-5 py-[5px] items-center justify-between border-b">
-      <div className="flex flex-col">
-        <span className="text-xl font-medium text-myDocumentNameColor">
-          {name}
-        </span>
-        <span className="text-[#A0A0A0] text-xs">몇 초 전</span>
+    <Link
+      href={`/document/${documentId}`}
+      className="flex items-center justify-between border-b border-gray200 px-5 py-2.5 hover:bg-gray50 transition-all"
+    >
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        <span className="truncate text-medium18 text-gray800">{name}</span>
+        <span className="text-medium12 text-gray400">{timeLabel}</span>
       </div>
-      <span className="text-xl">{`${views} 회`}</span>
-    </div>
+      <span className="whitespace-nowrap text-medium16 text-gray600">{`${views}회`}</span>
+    </Link>
   );
 };
 

--- a/src/components/sideBar/sideBar.tsx
+++ b/src/components/sideBar/sideBar.tsx
@@ -1,51 +1,119 @@
-import DocumentPreview from "./documentPreview";
+"use client";
+
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchSidebarPopularDocuments,
+  fetchSidebarRecentDocuments,
+  SidebarDocumentItem,
+} from "@/apis";
+import DocumentPreview from "./documentPreview";
 
-const SideBar = () => {
+interface SideBarProps {
+  className?: string;
+}
+
+const SidebarSection = ({
+  title,
+  moreLink,
+  documents,
+  isLoading,
+}: {
+  title: string;
+  moreLink: string;
+  documents?: SidebarDocumentItem[];
+  isLoading: boolean;
+}) => {
   return (
-    <div className="flex flex-col gap-10  w-[300px] mt-5">
-      <div className="bg-white rounded-2xl">
-        <div className="px-5 py-[10px] border-b">
-          <span className="font-bold text-base">최근 변경된 문서</span>
+    <div className="overflow-hidden rounded-2xl border border-gray200 bg-white">
+      <div className="border-b border-gray200 px-5 py-3">
+        <span className="text-semibold18 text-gray800">{title}</span>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-2 px-5 py-4">
+          {[0, 1, 2].map(index => (
+            <div
+              key={index}
+              className="h-11 w-full rounded-lg bg-gray100 animate-pulse"
+            />
+          ))}
         </div>
-        <DocumentPreview documentName="박자민" time={456} views={54} />
-        <DocumentPreview documentName="박지민" time={456} views={5948} />
-        <DocumentPreview documentName="박지미" time={789} views={3} />
-        <DocumentPreview documentName="빡지민" time={6155} views={1004} />
-        <DocumentPreview documentName="박시민" time={6155} views={7942} />
-        <DocumentPreview documentName="부지민" time={6155} views={1592} />
-        <DocumentPreview documentName="반지민" time={6155} views={5877} />
-        <DocumentPreview documentName="박지마" time={6155} views={4485} />
-        <DocumentPreview documentName="보지민" time={6155} views={6974} />
-        <DocumentPreview documentName="박주민" time={6155} views={32} />
-        <div className="px-5 py-[10px] flex justify-end">
-          <Link href={"/recent"}>
-            <span>더보기</span>
+      ) : (
+        <>
+          {documents?.slice(0, 6).map(document => (
+            <DocumentPreview
+              key={document.id}
+              documentId={document.id}
+              documentName={document.title}
+              minutesAgo={document.minutesAgo}
+              views={document.views}
+            />
+          ))}
+          <div className="flex justify-end px-5 py-3">
+            <Link
+              href={moreLink}
+              className="rounded-md px-2 py-1 text-medium14 text-lime500 hover:bg-lime50"
+            >
+              더보기
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const SideBar = ({ className }: SideBarProps) => {
+  const { data: recentDocuments, isLoading: isRecentLoading } = useQuery({
+    queryKey: ["sidebar-recent-documents"],
+    queryFn: fetchSidebarRecentDocuments,
+  });
+
+  const { data: popularDocuments, isLoading: isPopularLoading } = useQuery({
+    queryKey: ["sidebar-popular-documents"],
+    queryFn: fetchSidebarPopularDocuments,
+  });
+
+  return (
+    <aside className={`flex w-full flex-col gap-4 ${className ?? ""}`}>
+      <div className="rounded-2xl border border-gray200 bg-white p-4">
+        <p className="text-semibold16 text-gray700">바로가기</p>
+        <div className="mt-3 grid grid-cols-3 gap-2 sm:grid-cols-1">
+          <Link
+            href="/recent"
+            className="flex min-h-[44px] items-center justify-center rounded-lg bg-gray50 px-3 text-medium14 text-gray700 hover:bg-gray100"
+          >
+            최근 변경
+          </Link>
+          <Link
+            href="/popular"
+            className="flex min-h-[44px] items-center justify-center rounded-lg bg-gray50 px-3 text-medium14 text-gray700 hover:bg-gray100"
+          >
+            인기 문서
+          </Link>
+          <Link
+            href="/document/1"
+            className="flex min-h-[44px] items-center justify-center rounded-lg bg-lime100 px-3 text-medium14 text-lime500 hover:bg-lime200"
+          >
+            문서 바로가기
           </Link>
         </div>
       </div>
 
-      <div className="bg-white rounded-2xl">
-        <div className="px-5 py-[10px] border-b">
-          <span className="font-bold text-base">인기 TOP 10</span>
-        </div>
-        <DocumentPreview documentName="박시민" time={6155} views={7942} />
-        <DocumentPreview documentName="보지민" time={6155} views={6974} />
-        <DocumentPreview documentName="박지민" time={456} views={5948} />
-        <DocumentPreview documentName="반지민" time={6155} views={5877} />
-        <DocumentPreview documentName="박지마" time={6155} views={4485} />
-        <DocumentPreview documentName="부지민" time={6155} views={1592} />
-        <DocumentPreview documentName="빡지민" time={6155} views={1004} />
-        <DocumentPreview documentName="박자민" time={456} views={54} />
-        <DocumentPreview documentName="박주민" time={6155} views={32} />
-        <DocumentPreview documentName="박지미" time={789} views={3} />
-        <div className="px-5 py-[10px] flex justify-end">
-          <Link href={"/popular"}>
-            <span>더보기</span>
-          </Link>
-        </div>
-      </div>
-    </div>
+      <SidebarSection
+        title="최근 변경된 문서"
+        moreLink="/recent"
+        documents={recentDocuments}
+        isLoading={isRecentLoading}
+      />
+      <SidebarSection
+        title="인기 TOP 10"
+        moreLink="/popular"
+        documents={popularDocuments}
+        isLoading={isPopularLoading}
+      />
+    </aside>
   );
 };
 


### PR DESCRIPTION
## Summary
- add sidebar data API layer and hook sidebar sections to recent/popular document feeds with loading states
- redesign sidebar cards and preview rows for responsive layout, direct document links, and quick shortcuts (recent/popular/document)
- integrate sidebar into the onboarding main page layout so sidebar interactions are accessible in the live app flow

## Validation
- `lsp_diagnostics` clean on:
  - `src/apis/sidebar.ts`
  - `src/components/sideBar/documentPreview.tsx`
  - `src/components/sideBar/sideBar.tsx`
  - `src/app/(with-header)/main/page.tsx`
- `yarn tsc --noEmit` blocked in this worktree by Yarn workspace lock state (`daemawiki@workspace:.` missing in lockfile)

Closes #2