### PR TITLE
chore :: 변경 파일 기준 lint 명령 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:changed": "node scripts/lint-changed.mjs"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.1.0",

--- a/scripts/lint-changed.mjs
+++ b/scripts/lint-changed.mjs
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const baseRef = args[0] || process.env.LINT_BASE_REF || "origin/dev";
+const forwardArgs = args.slice(1);
+
+const runGit = gitArgs =>
+  spawnSync("git", gitArgs, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+const mergeBaseResult = runGit(["merge-base", "HEAD", baseRef]);
+
+if (mergeBaseResult.status !== 0) {
+  const errorOutput =
+    mergeBaseResult.stderr.trim() ||
+    `Unable to determine merge-base against ${baseRef}.`;
+  process.stderr.write(`[lint:changed] ${errorOutput}\n`);
+  process.stderr.write(
+    "[lint:changed] Try running `git fetch origin` or provide a different base ref.\n",
+  );
+  process.exit(mergeBaseResult.status || 1);
+}
+
+const mergeBase = mergeBaseResult.stdout.trim();
+const diffResult = runGit([
+  "diff",
+  "--name-only",
+  "--diff-filter=ACMR",
+  `${mergeBase}...HEAD`,
+]);
+
+if (diffResult.status !== 0) {
+  const errorOutput =
+    diffResult.stderr.trim() || "Unable to list changed files.";
+  process.stderr.write(`[lint:changed] ${errorOutput}\n`);
+  process.exit(diffResult.status || 1);
+}
+
+const lintableFilePattern = /\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/;
+const nextLintPathPattern = /^(app|pages|components|lib|src)\//;
+const changedFiles = diffResult.stdout
+  .split("\n")
+  .map(filePath => filePath.trim())
+  .filter(Boolean)
+  .filter(filePath => lintableFilePattern.test(filePath))
+  .filter(filePath => nextLintPathPattern.test(filePath))
+  .filter(filePath => !filePath.endsWith(".d.ts"));
+
+if (changedFiles.length === 0) {
+  process.stdout.write(
+    `[lint:changed] No changed JS/TS files since ${baseRef}.\n`,
+  );
+  process.exit(0);
+}
+
+process.stdout.write(`[lint:changed] Base ref: ${baseRef}\n`);
+process.stdout.write(
+  `[lint:changed] Linting ${changedFiles.length} file(s):\n`,
+);
+changedFiles.forEach(filePath => process.stdout.write(`- ${filePath}\n`));
+
+const lintArgs = ["next", "lint"];
+changedFiles.forEach(filePath => {
+  lintArgs.push("--file", filePath);
+});
+lintArgs.push(...forwardArgs);
+
+const lintRun = spawnSync("yarn", lintArgs, {
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (typeof lintRun.status === "number") {
+  process.exit(lintRun.status);
+}
+
+process.stderr.write("[lint:changed] Lint process terminated unexpectedly.\n");
+process.exit(1);


### PR DESCRIPTION
## Summary
- `yarn lint:changed` 스크립트를 추가해 `origin/dev` 대비 변경된 JS/TS 파일만 선택적으로 lint 하도록 했습니다.
- `scripts/lint-changed.mjs`에서 merge-base를 계산하고 `next lint --file` 인자로 파일 목록을 전달합니다.
- 전체 레포 lint 실패 상태와 별개로, 브랜치 단위 검증을 빠르게 수행할 수 있는 최소 기준선을 마련했습니다.

## Verification
- [x] `yarn install`
- [x] `yarn tsc --noEmit`
- [x] `yarn lint:changed`
- [x] `yarn lint` (pre-existing failures remain)
- [x] `yarn lint:changed origin/dev~1` (smoke check: changed src files are detected)