### PR TITLE
chore :: division 라우트 lint 오류 정리

### DIFF
--- a/src/app/(with-header)/division/Card.tsx
+++ b/src/app/(with-header)/division/Card.tsx
@@ -1,4 +1,10 @@
-import { Arrow_Short, Book, Notebook, User, Warn } from "@/assets";
+import {
+  Arrow_Short as ArrowShort,
+  Book,
+  Notebook,
+  User,
+  Warn,
+} from "@/assets";
 
 interface CardProps {
   longWidth?: boolean;
@@ -6,47 +12,60 @@ interface CardProps {
   onClick?: () => void;
 }
 
-export const Card = ({ longWidth, type, onClick }: CardProps) => {
-  const cardIcon = {
-    student: {
-      icon: <User />,
-      title: "학생",
-      details: "대마고의 이상한 학생들을\n구경해보세요.",
-    },
-    teacher: {
-      icon: <Book />,
-      title: "선생님",
-      details: "대마고의 선생님들을\n확인해보세요.",
-    },
-    accident: {
-      icon: <Warn />,
-      title: "사건/사고",
-      details: "대마고의 신박한 사건사고를\n확인해보세요.",
-    },
-    club: {
-      icon: <Notebook />,
-      title: "동아리",
-      details: "다양한 동아리들을\n만나보세요.",
-    },
-  };
+const cardIconMap = {
+  student: {
+    icon: <User />,
+    title: "학생",
+    details: "대마고의 이상한 학생들을\n구경해보세요.",
+  },
+  teacher: {
+    icon: <Book />,
+    title: "선생님",
+    details: "대마고의 선생님들을\n확인해보세요.",
+  },
+  accident: {
+    icon: <Warn />,
+    title: "사건/사고",
+    details: "대마고의 신박한 사건사고를\n확인해보세요.",
+  },
+  club: {
+    icon: <Notebook />,
+    title: "동아리",
+    details: "다양한 동아리들을\n만나보세요.",
+  },
+};
+
+function Card({ longWidth = false, type, onClick = undefined }: CardProps) {
+  const currentCard = cardIconMap[type];
+
   return (
-    <div
+    <button
+      type="button"
       onClick={onClick}
-      className={`w-full group hover:shadow-lg ${longWidth ? "max-w-[468px]" : "max-w-[260px]"} min-w-[220px] flex flex-col justify-between px-6 py-7 bg-white border border-gray200 rounded-2xl h-[260px] transition-all`}
+      className={`w-full group hover:shadow-lg ${longWidth ? "max-w-[468px]" : "max-w-[260px]"} min-w-[220px] flex flex-col justify-between px-6 py-7 bg-white border border-gray200 rounded-2xl h-[260px] transition-all text-left`}
     >
       <div className="w-full flex justify-between">
         <div className="rounded-lg flex bg-lime50 border border-lime300 p-2.5 text-lime500">
-          {cardIcon[type].icon}
+          {currentCard.icon}
         </div>
-        <Arrow_Short
+        <ArrowShort
           direction={longWidth ? "upRight" : "right"}
           className="text-gray200 opacity-0 cursor-pointer group-hover:opacity-100 transition-all"
         />
       </div>
       <div className="w-full flex flex-col gap-2">
-        <p className="text-bold28 text-black">{cardIcon[type].title}</p>
-        <p className="text-medium16 text-gray500">{cardIcon[type].details}</p>
+        <p className="text-bold28 text-black">{currentCard.title}</p>
+        <p className="text-medium16 text-gray500 whitespace-pre-line">
+          {currentCard.details}
+        </p>
       </div>
-    </div>
+    </button>
   );
+}
+
+Card.defaultProps = {
+  longWidth: false,
+  onClick: undefined,
 };
+
+export default Card;

--- a/src/app/(with-header)/division/page.tsx
+++ b/src/app/(with-header)/division/page.tsx
@@ -1,6 +1,5 @@
 import { Title } from "../document/[id]/Title";
-import { Card } from "./Card";
-import StudentPage from "./student/page";
+import Card from "./Card";
 
 export default function Division() {
   return (

--- a/src/app/(with-header)/division/student/page.tsx
+++ b/src/app/(with-header)/division/student/page.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { Arrow } from "@/assets";
-import { Title } from "../../document/[id]/Title";
 import { RegisterInput } from "@/components";
 import { periodMenu, majorMenu, clubMenu } from "@/constant/dropdownItem";
+import { Title } from "../../document/[id]/Title";
 import { Pagination } from "../../recent/Pagination";
 import { List } from "../../recent/List";
 
 function StudentPage() {
-  const arr = new Array(10).fill({
+  const arr = Array.from({ length: 10 }, (_, index) => ({
+    id: `student-${index}`,
     title: "이태영",
     group: "학생",
     changeUserName: "김승원",
     changeTime: "2424-08-28 08:37",
-  });
+  }));
   return (
     <div className="w-full flex justify-center">
       <div className="flex flex-col w-full max-w-[1200px]">
@@ -52,9 +53,9 @@ function StudentPage() {
               changeUserName="변경자"
               changeTime="변경 시간"
             />
-            {arr.map(({ title, group, changeUserName, changeTime }, index) => (
+            {arr.map(({ id, title, group, changeUserName, changeTime }) => (
               <List
-                key={index}
+                key={id}
                 title={title}
                 group={group}
                 changeUserName={changeUserName}


### PR DESCRIPTION
## Summary
- `src/app/(with-header)/division/Card.tsx`의 접근성/컴포넌트 규칙 위반을 정리했습니다.
- `Card`를 함수 선언 + default export로 정리하고, 클릭 컨테이너를 `button`으로 변경했습니다.
- `division/page.tsx`의 미사용 import 제거와 `student/page.tsx`의 import 순서/키 생성 규칙 위반을 정리했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/division/Card.tsx --file src/app/(with-header)/division/page.tsx --file src/app/(with-header)/division/student/page.tsx`
- [x] `yarn tsc --noEmit`