### PR TITLE
chore :: document 상세 컴포넌트 lint 오류 정리

### DIFF
--- a/src/app/(with-header)/document/[id]/Bottom.tsx
+++ b/src/app/(with-header)/document/[id]/Bottom.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const Bottom = () => {
+function Bottom() {
   const documentList = [
     "관련 문서",
     "이태영",
@@ -13,7 +13,7 @@ export const Bottom = () => {
       <div className="flex flex-wrap gap-2 pb-4">
         {documentList.map((text, index) => (
           <span
-            key={index}
+            key={text}
             className="text-lime500 text-medium14 hover:text-lime600 cursor-pointer"
           >
             {text}
@@ -21,9 +21,10 @@ export const Bottom = () => {
           </span>
         ))}
       </div>
-      <p className="text-gray400 text-medium12">
-        최근 수정: 2024-08-04 07:03
-      </p>
+      <p className="text-gray400 text-medium12">최근 수정: 2024-08-04 07:03</p>
     </div>
   );
-};
+}
+
+export { Bottom };
+export default Bottom;

--- a/src/app/(with-header)/document/[id]/InfoCard.tsx
+++ b/src/app/(with-header)/document/[id]/InfoCard.tsx
@@ -5,7 +5,7 @@ interface CardProps {
   text?: string;
 }
 
-export const InfoCard = ({ title, text }: CardProps) => {
+function InfoCard({ title, text }: CardProps) {
   return (
     <div className="flex flex-col gap-2 p-4 bg-gray50 rounded-lg">
       <span className="text-lime500 text-semibold14">{title}</span>
@@ -14,4 +14,11 @@ export const InfoCard = ({ title, text }: CardProps) => {
       </span>
     </div>
   );
+}
+
+InfoCard.defaultProps = {
+  text: "",
 };
+
+export { InfoCard };
+export default InfoCard;

--- a/src/app/(with-header)/document/[id]/Profile.tsx
+++ b/src/app/(with-header)/document/[id]/Profile.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import Image from "next/image";
 import { InfoCard } from "./InfoCard";
 
-export const Profile = () => {
+function Profile() {
   const infoArr = [
     { title: "학년", text: "3학년" },
     { title: "전공", text: "백엔드" },
@@ -26,17 +25,21 @@ export const Profile = () => {
             <p className="text-lime500 text-semibold14">2113 이태영</p>
           </div>
           <p className="text-gray600 text-medium18">
-            김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한 명입니다.
+            김승윤이 사랑한 김어진 박지민 이태영 최고의 인재 팀원 중 한
+            명입니다.
           </p>
         </div>
       </div>
 
       {/* Metadata Grid */}
       <div className="grid grid-cols-6 gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {infoArr.map(({ title, text }, index) => (
-          <InfoCard title={title} text={text} key={index} />
+        {infoArr.map(({ title, text }) => (
+          <InfoCard title={title} text={text} key={title} />
         ))}
       </div>
     </div>
   );
-};
+}
+
+export { Profile };
+export default Profile;

--- a/src/app/(with-header)/document/[id]/Title.tsx
+++ b/src/app/(with-header)/document/[id]/Title.tsx
@@ -11,7 +11,7 @@ interface TitleProps {
   lastModifiedTime?: string;
 }
 
-export const Title = ({
+function Title({
   group,
   title = "이태영",
   views = 210,
@@ -20,7 +20,7 @@ export const Title = ({
   noShow,
   additionalInfo,
   lastModifiedTime,
-}: TitleProps) => {
+}: TitleProps) {
   const metaText = lastModifiedTime
     ? `최근 수정 시각 : ${lastModifiedTime}`
     : additionalInfo ||
@@ -71,4 +71,18 @@ export const Title = ({
       </div>
     </div>
   );
+}
+
+Title.defaultProps = {
+  group: "",
+  title: "이태영",
+  views: 210,
+  details: "",
+  noPadding: false,
+  noShow: false,
+  additionalInfo: "",
+  lastModifiedTime: "",
 };
+
+export { Title };
+export default Title;


### PR DESCRIPTION
## Summary
- `Bottom`, `InfoCard`, `Profile`, `Title` 컴포넌트의 lint 오류를 최소 변경으로 정리했습니다.
- 함수형 컴포넌트 선언 방식/내보내기 규칙을 맞추고, 배열 index key 사용을 제거했습니다.
- optional prop 기본값, 미사용 import, prettier 포맷 위반을 함께 정리했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/document/[id]/Bottom.tsx --file src/app/(with-header)/document/[id]/InfoCard.tsx --file src/app/(with-header)/document/[id]/Profile.tsx --file src/app/(with-header)/document/[id]/Title.tsx`
- [x] `yarn tsc --noEmit`