### PR TITLE
chore :: document userInfo lint 오류 정리

### DIFF
--- a/src/app/(with-header)/document/[id]/userInfo/EditHistory.tsx
+++ b/src/app/(with-header)/document/[id]/userInfo/EditHistory.tsx
@@ -15,7 +15,15 @@ interface HistoryProps {
   text: string;
 }
 
-const EditHistory = ({
+function RemoveHistory({ text }: HistoryProps) {
+  return <span className="text-gray400 line-through">{text}</span>;
+}
+
+function AddedHistory({ text }: HistoryProps) {
+  return <span className="text-lime500">{text}</span>;
+}
+
+function EditHistory({
   index,
   title,
   editor,
@@ -24,14 +32,15 @@ const EditHistory = ({
   isOpen,
   handleOpen,
   isFirst,
-}: PropsType) => {
+}: PropsType) {
   const firstHistoryStyle = isFirst ? "border-t-[0px]" : "border-t-[1px]";
 
   return (
     <div
       className={`py-5 px-7 flex flex-col gap-3 ${firstHistoryStyle} border-gray200`}
     >
-      <div
+      <button
+        type="button"
         className="flex items-center text-medium18 text-black"
         onClick={handleOpen}
       >
@@ -42,30 +51,24 @@ const EditHistory = ({
         <div className="max-w-[240px] flex-grow">{editor}</div>
         <div className="flex-grow max-w-[240px]">{editDate}</div>
         <Arrow direction={isOpen ? "up" : "down"} />
-      </div>
+      </button>
       {isOpen && (
         <div className="flex-col flex px-3 gap-1 text-medium18 border-l-[1px] border-gray200">
           {editHistory
             .filter(history => history.added || history.removed)
-            .map(history =>
-              history.added ? (
-                <AddedHistory text={history.value} />
+            .map(history => {
+              const historyKey = `${history.value}-${history.added ? "a" : "r"}`;
+
+              return history.added ? (
+                <AddedHistory key={historyKey} text={history.value} />
               ) : (
-                <RemoveHistory text={history.value} />
-              ),
-            )}
+                <RemoveHistory key={historyKey} text={history.value} />
+              );
+            })}
         </div>
       )}
     </div>
   );
-};
-
-const RemoveHistory = ({ text }: HistoryProps) => {
-  return <span className="text-gray400 line-through">{text}</span>;
-};
-
-const AddedHistory = ({ text }: HistoryProps) => {
-  return <span className="text-lime500">{text}</span>;
-};
+}
 
 export default EditHistory;

--- a/src/app/(with-header)/document/[id]/userInfo/page.tsx
+++ b/src/app/(with-header)/document/[id]/userInfo/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useState } from "react";
+import { Calendar, User } from "@/assets";
 import { Sidebar } from "@/components";
 import { Title } from "../Title";
-import { User, Calendar } from "@/assets";
 import EditHistory from "./EditHistory";
-import { useState } from "react";
 
 interface MockDataType {
   index: string;
@@ -62,10 +62,10 @@ export default function UserInfo() {
     },
   ];
 
-  const [openHistory, setOpenHistory] = useState<number | null>(null);
+  const [openHistory, setOpenHistory] = useState<string | null>(null);
 
-  const handleOpen = (number: number) => {
-    setOpenHistory(prev => (prev === number ? null : number));
+  const handleOpen = (id: string) => {
+    setOpenHistory(prev => (prev === id ? null : id));
   };
 
   return (
@@ -102,7 +102,7 @@ export default function UserInfo() {
                 <div className="flex gap-5 items-center">
                   <div className="w-[100px] text-medium18">분류</div>
                   <div className="flex px-3 py-[6px] gap-[10px] rounded-full bg-lime100 items-center">
-                    <div className="w-[10px] h-[10px] rounded-full bg-lime400"></div>
+                    <div className="w-[10px] h-[10px] rounded-full bg-lime400" />
                     <span className="whitespace-nowrap">학생</span>
                   </div>
                 </div>
@@ -135,29 +135,36 @@ export default function UserInfo() {
                   <div className="flex-grow">목차</div>
                   <div className="flex-grow max-w-[240px]">이름</div>
                   <div className="flex-grow max-w-[240px]">날짜</div>
-                  <div className="w-6"></div>
+                  <div className="w-6" />
                 </div>
               </div>
               {MockData.map(
-                ({ index, title, editor, editDate, editHistory }, key) => (
-                  <EditHistory
-                    key={key}
-                    index={index}
-                    title={title}
-                    editor={editor}
-                    editDate={editDate}
-                    editHistory={editHistory}
-                    isOpen={openHistory === key}
-                    handleOpen={() => handleOpen(key)}
-                    isFirst={key === 0}
-                  />
-                ),
+                (
+                  { index, title, editor, editDate, editHistory },
+                  historyIndex,
+                ) => {
+                  const historyId = `${editDate}-${index}-${title}`;
+
+                  return (
+                    <EditHistory
+                      key={historyId}
+                      index={index}
+                      title={title}
+                      editor={editor}
+                      editDate={editDate}
+                      editHistory={editHistory}
+                      isOpen={openHistory === historyId}
+                      handleOpen={() => handleOpen(historyId)}
+                      isFirst={historyIndex === 0}
+                    />
+                  );
+                },
               )}
             </div>
           </div>
         </div>
       </div>
-      <section className="max-w-[1200px]"></section>
+      <section className="max-w-[1200px]" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `userInfo/EditHistory.tsx`의 함수 선언 규칙, 접근성 규칙, key 누락, use-before-define 이슈를 정리했습니다.
- `userInfo/page.tsx`의 import 순서, self-closing 규칙, 배열 index key 사용을 정리했습니다.
- 문서 수정 내역 토글 동작은 유지하면서 lint 규칙 위반만 최소 변경으로 해결했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/document/[id]/userInfo/EditHistory.tsx --file src/app/(with-header)/document/[id]/userInfo/page.tsx`
- [x] `yarn tsc --noEmit`