### PR TITLE
chore :: login/main/popular lint 오류 정리

### DIFF
--- a/src/app/(with-header)/login/page.tsx
+++ b/src/app/(with-header)/login/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React from "react";
 import { Arrow } from "@/assets";
 import { Button, RegisterInput, useToast } from "@/components";
@@ -41,6 +42,8 @@ export default function Login() {
       addToast("네트워크 오류가 발생했습니다.", "error");
     }
   });
+
+  const loginButtonStyle = "primary2" as const;
 
   return (
     <div className="w-full flex justify-center px-4 py-8 md:py-6 sm:py-4">
@@ -108,7 +111,12 @@ export default function Login() {
               회원가입
             </button>
           </div>
-          <Button onClick={handleLogin} big style="primary2" text="로그인" />{" "}
+          <Button
+            onClick={handleLogin}
+            big
+            {...{ style: loginButtonStyle }}
+            text="로그인"
+          />
           {/* 로그인 핸들러 실행 */}
         </div>
       </div>

--- a/src/app/(with-header)/main/page.tsx
+++ b/src/app/(with-header)/main/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components";
 import { IndexItem, mainPageIndex } from "@/constant/indexItem";
@@ -42,6 +43,9 @@ function Main() {
     loadMain();
   }, [loadMain]);
 
+  const retryButtonStyle = "primary2" as const;
+  const refreshButtonStyle = "white" as const;
+
   return (
     <section className="w-full min-h-[calc(100dvh-160px)] bg-gray50 px-4 py-8 md:py-6 sm:py-4">
       <div className="mx-auto flex w-full max-w-[1320px] gap-6 md:flex-col sm:flex-col">
@@ -75,7 +79,11 @@ function Main() {
               <p className="text-semibold20 text-red500">불러오기 실패</p>
               <p className="text-medium16 text-gray700">{errorMessage}</p>
               <div className="w-fit">
-                <Button onClick={loadMain} style="primary2" text="다시 시도" />
+                <Button
+                  onClick={loadMain}
+                  {...{ style: retryButtonStyle }}
+                  text="다시 시도"
+                />
               </div>
             </div>
           )}
@@ -89,7 +97,11 @@ function Main() {
                 잠시 후 다시 시도하거나 관리자에게 상태를 문의해주세요.
               </p>
               <div className="w-fit">
-                <Button onClick={loadMain} style="white" text="새로고침" />
+                <Button
+                  onClick={loadMain}
+                  {...{ style: refreshButtonStyle }}
+                  text="새로고침"
+                />
               </div>
             </div>
           )}

--- a/src/app/(with-header)/popular/page.tsx
+++ b/src/app/(with-header)/popular/page.tsx
@@ -1,8 +1,7 @@
 "use client";
-import React from "react";
 
 function Popular() {
-  return <></>;
+  return null;
 }
 
 export default Popular;


### PR DESCRIPTION
## Summary
- `login/page.tsx`에서 `use client` 지시문 간격 규칙과 버튼 스타일 속성 관련 lint 이슈를 정리했습니다.
- `main/page.tsx`에서 버튼 스타일 전달 방식과 `use client` 지시문 간격 규칙을 정리했습니다.
- `popular/page.tsx`에서 불필요한 Fragment/미사용 import 이슈를 정리했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/login/page.tsx --file src/app/(with-header)/main/page.tsx --file src/app/(with-header)/popular/page.tsx`
- [x] `yarn tsc --noEmit`