### PR TITLE
chore :: recent 라우트 lint 오류 정리

### DIFF
--- a/src/app/(with-header)/recent/List.tsx
+++ b/src/app/(with-header)/recent/List.tsx
@@ -8,13 +8,13 @@ interface ListProps {
   changeTime?: string;
 }
 
-export const List = ({
+function List({
   listTitle,
   title,
   group,
   changeUserName,
   changeTime,
-}: ListProps) => {
+}: ListProps) {
   return (
     <div
       className={`w-full gap-2 flex items-center p-5 ${listTitle ? "bg-gray50" : "bg-white border-b border-b-gray100"}`}
@@ -24,7 +24,7 @@ export const List = ({
       >
         {title}
       </p>
-      <div className={`w-full flex items-center gap-2`}>
+      <div className="w-full flex items-center gap-2">
         <p
           className={`w-full ${listTitle ? "text-medium18 text-gray700" : "text-medium16 text-gray500"}`}
         >
@@ -43,4 +43,15 @@ export const List = ({
       </div>
     </div>
   );
+}
+
+List.defaultProps = {
+  listTitle: false,
+  title: "",
+  group: "",
+  changeUserName: "",
+  changeTime: "",
 };
+
+export { List };
+export default List;

--- a/src/app/(with-header)/recent/Pagination.tsx
+++ b/src/app/(with-header)/recent/Pagination.tsx
@@ -1,23 +1,30 @@
 import React from "react";
 import { Arrow } from "@/assets";
 
-export const Pagination = () => {
+function Pagination() {
   const arr = [1, 2, 3, 4, 5];
+
   return (
     <div className="w-full flex justify-center gap-7 px-6">
       <div className="flex cursor-pointer p-1.5 rounded-lg hover:bg-gray100">
         <Arrow className="text-gray700" />
       </div>
       <div className="flex items-center">
-        {arr.map((item, index) => (
-          <div className=" cursor-pointer rounded-lg h-9 w-9 flex items-center justify-center hover:bg-lime50">
+        {arr.map(item => (
+          <div
+            key={item}
+            className=" cursor-pointer rounded-lg h-9 w-9 flex items-center justify-center hover:bg-lime50"
+          >
             {item}
           </div>
         ))}
       </div>
-      <div className={`flex cursor-pointer p-1.5 rounded-lg hover:bg-gray100`}>
+      <div className="flex cursor-pointer p-1.5 rounded-lg hover:bg-gray100">
         <Arrow direction="right" className="text-gray700" />
       </div>
     </div>
   );
-};
+}
+
+export { Pagination };
+export default Pagination;

--- a/src/app/(with-header)/recent/page.tsx
+++ b/src/app/(with-header)/recent/page.tsx
@@ -4,12 +4,14 @@ import { List } from "./List";
 import { Pagination } from "./Pagination";
 
 function Recent() {
-  const arr = new Array(10).fill({
+  const arr = Array.from({ length: 10 }, (_, index) => ({
+    id: `recent-${index}`,
     title: "이태영",
     group: "학생",
     changeUserName: "김승원",
     changeTime: "2424-08-28 08:37",
-  });
+  }));
+
   return (
     <div className="w-full flex justify-center pb-12">
       <div className="w-full pt-16 px-12 max-w-[1200px] flex flex-col gap-14">
@@ -28,9 +30,9 @@ function Recent() {
             changeUserName="변경자"
             changeTime="변경 시간"
           />
-          {arr.map(({ title, group, changeUserName, changeTime }, index) => (
+          {arr.map(({ id, title, group, changeUserName, changeTime }) => (
             <List
-              key={index}
+              key={id}
               title={title}
               group={group}
               changeUserName={changeUserName}


### PR DESCRIPTION
## Summary
- `recent/List.tsx`에서 컴포넌트 선언/내보내기 규칙, optional props 기본값, 불필요한 JSX 중괄호 이슈를 정리했습니다.
- `recent/Pagination.tsx`에서 key 누락, 미사용 변수, 컴포넌트 선언/내보내기 규칙 이슈를 정리했습니다.
- `recent/page.tsx`에서 배열 index key 사용을 제거하고 안정적인 id key로 교체했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/recent/List.tsx --file src/app/(with-header)/recent/Pagination.tsx --file src/app/(with-header)/recent/page.tsx`
- [x] `yarn tsc --noEmit`