### PR TITLE
chore :: signup 라우트 lint 오류 정리

### DIFF
--- a/src/app/(with-header)/signup/Register.tsx
+++ b/src/app/(with-header)/signup/Register.tsx
@@ -1,7 +1,7 @@
 "use client";
-import React, { useEffect, useRef, useState } from "react";
+
+import React, { useRef, useState } from "react";
 import { Button, RegisterInput } from "@/components";
-import { useRouter } from "next/navigation";
 import { periodMenu, majorMenu } from "@/constant/dropdownItem";
 import { Controller, FieldErrors, Control, useWatch } from "react-hook-form";
 import { SignupFormValues } from "@/interfaces/user";
@@ -12,7 +12,7 @@ interface SignupFormProps {
   errors: FieldErrors<SignupFormValues>;
 }
 
-export const Email = ({ control, errors }: SignupFormProps) => {
+export function Email({ control, errors }: SignupFormProps) {
   return (
     <div className="flex flex-col gap-6 w-full">
       <Controller
@@ -39,22 +39,24 @@ export const Email = ({ control, errors }: SignupFormProps) => {
       />
     </div>
   );
-};
+}
 
-export const EmailVerification = ({ control, errors }: SignupFormProps) => {
+export function EmailVerification({ control, errors }: SignupFormProps) {
   const email = useWatch({ control, name: "email" });
 
   const [verificationCode, setVerificationCode] = useState<string[]>(
     new Array(6).fill(""),
   );
   const inputRef = useRef<(HTMLInputElement | null)[]>([]);
+  const otpSlotIds = ["0", "1", "2", "3", "4", "5"];
+  const resendButtonStyle = "primary2" as const;
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     index: number,
     onChange: (value: string) => void,
   ) => {
-    const value = e.target.value;
+    const { value } = e.target;
     const newOtp = [...verificationCode];
     newOtp[index] = value;
     setVerificationCode(newOtp);
@@ -98,39 +100,48 @@ export const EmailVerification = ({ control, errors }: SignupFormProps) => {
           message: "인증 코드는 6자리여야 합니다.",
         },
       }}
-      render={({ field: { value, onChange } }) => (
+      render={({ field: { onChange } }) => (
         <div className="w-full flex flex-col gap-3">
           <div className="w-full flex gap-2 justify-center">
-            {verificationCode.map((code, index) => (
-              <div
-                key={index}
-                className="w-16 h-16 focus-within:bg-white bg-gray50 rounded-lg flex justify-center items-center border border-gray300"
-              >
-                <input
-                  value={code}
-                  onChange={e => handleChange(e, index, onChange)}
-                  onKeyDown={e => handleKeyDown(e, index)}
-                  ref={e => inputRefEvent(e, index)}
-                  maxLength={1}
-                  className="text-center text-black text-semibold24 bg-transparent w-full"
-                />
-              </div>
-            ))}
+            {otpSlotIds.map((slotId, index) => {
+              const code = verificationCode[index] ?? "";
+
+              return (
+                <div
+                  key={slotId}
+                  className="w-16 h-16 focus-within:bg-white bg-gray50 rounded-lg flex justify-center items-center border border-gray300"
+                >
+                  <input
+                    value={code}
+                    onChange={e => handleChange(e, index, onChange)}
+                    onKeyDown={e => handleKeyDown(e, index)}
+                    ref={e => inputRefEvent(e, index)}
+                    maxLength={1}
+                    className="text-center text-black text-semibold24 bg-transparent w-full"
+                  />
+                </div>
+              );
+            })}
           </div>
           <div className="w-full flex justify-between">
             <p className="text-medium14 text-red500 ml-2">
               {errors.verificationCode?.message}
             </p>
-            <Button onClick={reSendMail} style="primary2" text="재전송" />
+            <Button
+              onClick={reSendMail}
+              {...{ style: resendButtonStyle }}
+              text="재전송"
+            />
           </div>
         </div>
       )}
     />
   );
-};
+}
 
-export const Password = ({ control, errors }: SignupFormProps) => {
+export function Password({ control, errors }: SignupFormProps) {
   const password = useWatch({ control, name: "password" });
+
   return (
     <div className="flex flex-col gap-6 w-full">
       <Controller
@@ -179,9 +190,9 @@ export const Password = ({ control, errors }: SignupFormProps) => {
       />
     </div>
   );
-};
+}
 
-export const Name = ({ control, errors }: SignupFormProps) => {
+export function Name({ control, errors }: SignupFormProps) {
   if (!control) return null;
 
   return (
@@ -216,13 +227,13 @@ export const Name = ({ control, errors }: SignupFormProps) => {
         rules={{ required: "기수를 선택해주세요." }}
         render={({ field: { onChange, value } }) => (
           <RegisterInput
-            dropdownValue={[...periodMenu].reverse().map(i => i + "기")}
+            dropdownValue={[...periodMenu].reverse().map(i => `${i}기`)}
             type="dropdown"
             placeholder="기수 선택"
             title="기수"
             value={value}
             onChange={selectedValue =>
-              onChange(parseInt(selectedValue.slice(0, -1)))
+              onChange(parseInt(selectedValue.slice(0, -1), 10))
             }
           />
         )}
@@ -244,4 +255,4 @@ export const Name = ({ control, errors }: SignupFormProps) => {
       />
     </div>
   );
-};
+}

--- a/src/app/(with-header)/signup/page.tsx
+++ b/src/app/(with-header)/signup/page.tsx
@@ -1,13 +1,14 @@
 "use client";
+
 import React, { useState } from "react";
 import { Arrow } from "@/assets";
 import { Button, useToast } from "@/components";
 import { useRouter } from "next/navigation";
-import { Email, EmailVerification, Name, Password } from "./Register";
 import { useForm, useWatch } from "react-hook-form";
 import { SignupFormValues } from "@/interfaces/user";
 import { mailSend, mailVerify } from "@/apis/mail";
 import { registerHandler } from "@/apis";
+import { Email, EmailVerification, Name, Password } from "./Register";
 
 export default function Signup() {
   const { addToast } = useToast();
@@ -31,23 +32,28 @@ export default function Signup() {
   const router = useRouter();
   const [pageNum, setPageNum] = useState<number>(0);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const signupButtonStyle = "primary2" as const;
   const page = [
     {
+      id: "email",
       page: <Email control={control} errors={errors} />,
       details: "이메일 인증을 위해 DSM 이메일을 입력해주세요",
       buttonText: "인증 코드 전송",
     },
     {
+      id: "verification",
       page: <EmailVerification control={control} errors={errors} />,
       details: `${email} 로 인증 코드를 전송했습니다`,
       buttonText: "확인",
     },
     {
+      id: "password",
       page: <Password control={control} errors={errors} />,
       details: "비밀번호를 설정해주세요",
       buttonText: "확인",
     },
     {
+      id: "profile",
       page: <Name control={control} errors={errors} />,
       details: "이름을 입력하고 기수와 전공을 선택해주세요",
       buttonText: "완료",
@@ -122,26 +128,11 @@ export default function Signup() {
     }
   });
 
-  const handleStepEnterSubmit = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key !== "Enter" || e.nativeEvent.isComposing) {
-      return;
-    }
-
-    const target = e.target as HTMLElement;
-
-    if (target.tagName === "TEXTAREA") {
-      return;
-    }
-
-    e.preventDefault();
-    nextStep();
-  };
-
   return (
     <div className="w-full flex justify-center px-4 py-8 md:py-6 sm:py-4">
-      <div
+      <form
         className="w-full max-w-[520px] flex flex-col gap-10 rounded-3xl border border-gray200 bg-white p-6 shadow-sm md:p-5 sm:p-4"
-        onKeyDown={handleStepEnterSubmit}
+        onSubmit={nextStep}
       >
         <button
           type="button"
@@ -162,21 +153,20 @@ export default function Signup() {
         </div>
         <div className="w-full flex flex-col gap-5">
           <div className="w-full gap-2 flex justify-center items-center">
-            {page.map((_, index) => (
+            {page.map((step, index) => (
               <div
-                key={index}
+                key={step.id}
                 className={`h-2 transition-all rounded-full ${pageNum === index ? "w-4 bg-lime400" : "w-2 bg-gray300"}`}
               />
             ))}
           </div>
           <Button
             big
-            onClick={nextStep}
-            style="primary2"
+            {...{ style: signupButtonStyle }}
             text={isSubmitting ? "처리 중..." : page[pageNum].buttonText}
           />
         </div>
-      </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `signup/Register.tsx`에서 함수형 컴포넌트 선언 규칙, key 규칙, style prop 규칙, 문자열/parseInt lint 이슈를 정리했습니다.
- `signup/page.tsx`에서 import 순서, 접근성(onKeyDown on static element), 배열 index key, style prop lint 이슈를 정리했습니다.
- 기존 회원가입 단계 흐름은 유지하면서 lint 규칙 위반만 최소 범위로 정리했습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/signup/Register.tsx --file src/app/(with-header)/signup/page.tsx`
- [x] `yarn tsc --noEmit`