### PR TITLE
chore :: team 라우트 lint 오류 정리

### DIFF
--- a/src/app/(with-header)/team/MemberCard.tsx
+++ b/src/app/(with-header)/team/MemberCard.tsx
@@ -8,7 +8,7 @@ interface CardProps {
   major?: string;
 }
 
-export const MemberCard = ({ name, img, github, major }: CardProps) => {
+function MemberCard({ name, img, github, major }: CardProps) {
   return (
     <div className="group rounded-lg w-full max-w-[270px] h-[360px] relative overflow-hidden">
       <div className="absolute translate-y-8 group-hover:translate-y-0 opacity-0 transition-all group-hover:opacity-100 z-10 self-center left-2.5 right-2.5 bottom-2.5 flex flex-col gap-1 p-4 rounded-md bg-white">
@@ -22,8 +22,19 @@ export const MemberCard = ({ name, img, github, major }: CardProps) => {
       </div>
       <img
         src={img || ""}
+        alt={name || "team member"}
         className="absolute w-full h-full grayscale group-hover:grayscale-0 transition-all"
       />
     </div>
   );
+}
+
+MemberCard.defaultProps = {
+  name: "",
+  img: "",
+  github: "",
+  major: "",
 };
+
+export { MemberCard };
+export default MemberCard;

--- a/src/app/(with-header)/team/ValuesCard.tsx
+++ b/src/app/(with-header)/team/ValuesCard.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   details: string;
 }
 
-export const ValuesCard = ({ index, title, details }: PropsType) => {
+function ValuesCard({ index, title, details }: PropsType) {
   return (
     <div className="border-gray200 w-full border rounded-2xl flex flex-col gap-4 p-6">
       <div className="flex w-11 h-11 justify-center items-center rounded-md bg-lime50">
@@ -14,4 +14,7 @@ export const ValuesCard = ({ index, title, details }: PropsType) => {
       <p className="text-medium16 text-gray500">{details}</p>
     </div>
   );
-};
+}
+
+export { ValuesCard };
+export default ValuesCard;

--- a/src/app/(with-header)/team/page.tsx
+++ b/src/app/(with-header)/team/page.tsx
@@ -1,8 +1,7 @@
 "use client";
+
 import React from "react";
-import { Arrow, TeamLogo } from "@/assets";
-import { Button, RegisterInput } from "@/components";
-import { useRouter } from "next/navigation";
+import { TeamLogo } from "@/assets";
 import { MemberCard } from "./MemberCard";
 import { ValuesCard } from "./ValuesCard";
 
@@ -36,27 +35,31 @@ export default function Team() {
 
   const rules = [
     {
+      id: "rule-1",
       title: "사용자 편의성을 중시해요",
       detail:
         "구성원에게 도덕성을 기대해요. 라운지를 깨끗하게 사용하는 것, 지각하지 않는 것, 법인카드 사용 규정을 잘 지키는 것 등 우리가 서로에게 약속한 모습들을 보여줘요.",
     },
     {
+      id: "rule-2",
       title: "사용자 편의성을 중시해요",
       detail:
         "구성원에게 도덕성을 기대해요. 라운지를 깨끗하게 사용하는 것, 지각하지 않는 것, 법인카드 사용 규정을 잘 지키는 것 등 우리가 서로에게 약속한 모습들을 보여줘요.",
     },
     {
+      id: "rule-3",
       title: "사용자 편의성을 중시해요",
       detail:
         "구성원에게 도덕성을 기대해요. 라운지를 깨끗하게 사용하는 것, 지각하지 않는 것, 법인카드 사용 규정을 잘 지키는 것 등 우리가 서로에게 약속한 모습들을 보여줘요.",
     },
     {
+      id: "rule-4",
       title: "사용자 편의성을 중시해요",
       detail:
         "구성원에게 도덕성을 기대해요. 라운지를 깨끗하게 사용하는 것, 지각하지 않는 것, 법인카드 사용 규정을 잘 지키는 것 등 우리가 서로에게 약속한 모습들을 보여줘요.",
     },
   ];
-  const router = useRouter();
+
   return (
     <div className="w-full flex justify-center flex-col">
       <div className="w-full max-w-[1200px] flex flex-col pt-16">
@@ -89,9 +92,9 @@ export default function Team() {
             </p>
           </div>
           <div className="w-full flex flex-wrap gap-2">
-            {member.map(({ name, img, github, major }, index) => (
+            {member.map(({ name, img, github, major }) => (
               <MemberCard
-                key={index}
+                key={name}
                 name={name}
                 img={img}
                 github={github}
@@ -112,16 +115,19 @@ export default function Team() {
             </p>
           </div>
           <div className="grid grid-cols-2 md:grid-cols-1 gap-6 w-full">
-            {rules.map(({ title, detail }, index) => (
+            {rules.map(({ id, title, detail }, index) => (
               <ValuesCard
-                key={index}
+                key={id}
                 index={index + 1}
                 title={title}
                 details={detail}
               />
             ))}
           </div>
-          <button className="rounded-full bg-gray100 px-4 py-3 flex text-medium16 w-max">
+          <button
+            type="button"
+            className="rounded-full bg-gray100 px-4 py-3 flex text-medium16 w-max"
+          >
             벨로그 보러가기
           </button>
         </div>
@@ -171,7 +177,10 @@ export default function Team() {
           <br />
           고개를 들어주세요.
         </p>
-        <button className="bg-gray900 text-medium16 text-white rounded-full px-4 py-3">
+        <button
+          type="button"
+          className="bg-gray900 text-medium16 text-white rounded-full px-4 py-3"
+        >
           대마위키 살펴보기
         </button>
       </div>


### PR DESCRIPTION
## Summary
- `team/MemberCard.tsx`, `team/ValuesCard.tsx`의 컴포넌트 선언/내보내기 및 optional prop 규칙 위반을 정리했습니다.
- `team/page.tsx`에서 `use client` 간격, 미사용 import/변수, index key, button type 누락을 정리했습니다.
- `MemberCard`의 이미지에 기본 alt를 추가해 접근성 경고를 줄였습니다.

## Verification
- [x] `yarn next lint --file src/app/(with-header)/team/MemberCard.tsx --file src/app/(with-header)/team/ValuesCard.tsx --file src/app/(with-header)/team/page.tsx`
- [x] `yarn tsc --noEmit`