### PR TITLE
chore :: toast 컴포넌트 lint 오류 정리

### DIFF
--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Check, Close, Info, Warn } from "@/assets";
 import React, { useEffect, useState } from "react";
 
@@ -7,8 +8,8 @@ type MessageType = "success" | "error" | "info" | "warning";
 interface ToastProps {
   message: string;
   type: MessageType;
-  onClose: () => void; // 닫기 핸들러
-  duration?: number; // 자동 닫힘 시간 (ms)
+  onClose: () => void;
+  duration?: number;
 }
 
 const typeStyles = {
@@ -34,19 +35,14 @@ const typeStyles = {
   },
 };
 
-export const Toast = ({
-  type,
-  message,
-  onClose,
-  duration = 3000,
-}: ToastProps) => {
+function Toast({ type, message, onClose, duration }: ToastProps) {
   const [visible, setVisible] = useState<boolean>(false);
 
   useEffect(() => {
     setVisible(true);
     const timer = setTimeout(() => {
-      setVisible(false); // 사라지는 애니메이션 시작
-      setTimeout(onClose, 300); // 애니메이션 끝난 후 컴포넌트 제거
+      setVisible(false);
+      setTimeout(onClose, 300);
     }, duration);
 
     return () => clearTimeout(timer);
@@ -65,9 +61,10 @@ export const Toast = ({
         <p>{message}</p>
       </div>
       <button
+        type="button"
         onClick={() => {
           setVisible(false);
-          setTimeout(onClose, 300); // 애니메이션 후 제거
+          setTimeout(onClose, 300);
         }}
         className="ml-4"
       >
@@ -75,4 +72,10 @@ export const Toast = ({
       </button>
     </div>
   );
+}
+
+Toast.defaultProps = {
+  duration: 3000,
 };
+
+export default Toast;

--- a/src/components/toast/ToastContext.ts
+++ b/src/components/toast/ToastContext.ts
@@ -1,4 +1,5 @@
 "use client";
+
 import { createContext, useContext } from "react";
 
 type MessageType = "success" | "error" | "info" | "warning";
@@ -7,10 +8,10 @@ export const ToastContext = createContext<{
   addToast: (message: string, type: MessageType) => void;
 } | null>(null);
 
-export const useToast = () => {
+export function useToast() {
   const context = useContext(ToastContext);
   if (!context) {
     throw new Error("useToast must be used within ToastContext.Provider");
   }
   return context;
-};
+}

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,3 +1,3 @@
-export * from "./Toast";
+export { default as Toast } from "./Toast";
 export * from "./ToastContext";
-export * from "./toastManager";
+export { default as useToastManager } from "./toastManager";

--- a/src/components/toast/toastManager.ts
+++ b/src/components/toast/toastManager.ts
@@ -1,5 +1,6 @@
 "use client";
-import React, { useState } from "react";
+
+import { useState } from "react";
 
 type MessageType = "success" | "error" | "info" | "warning";
 
@@ -9,7 +10,7 @@ interface ToastProps {
   type: MessageType;
 }
 
-export const useToastManager = () => {
+function useToastManager() {
   const [toasts, setToasts] = useState<ToastProps[]>([]);
 
   const addToast = (message: string, type: MessageType) => {
@@ -22,4 +23,6 @@ export const useToastManager = () => {
   };
 
   return { toasts, addToast, removeToast };
-};
+}
+
+export default useToastManager;


### PR DESCRIPTION
## Summary
- toast UI 컴포넌트의 directive spacing, 함수 선언 방식, 기본 props, button type 관련 lint 오류를 정리했습니다.
- toast context/manager의 directive spacing, default export 규칙, unused import 오류를 정리했습니다.
- `src/components/toast/index.ts`의 export 방식을 정리해 기존 사용처 호환성을 유지했습니다.

## Verification
- yarn next lint --file "src/components/toast/Toast.tsx" --file "src/components/toast/ToastContext.ts" --file "src/components/toast/toastManager.ts" --file "src/components/toast/index.ts"
- yarn tsc --noEmit