### PR TITLE
chore :: assets 아이콘 lint 오류 정리

### DIFF
--- a/src/assets/Arrow.tsx
+++ b/src/assets/Arrow.tsx
@@ -5,12 +5,12 @@ interface PropsType {
   direction?: "left" | "up" | "right" | "down";
 }
 
-export const Arrow = ({
+function Arrow({
   size = 24,
   className = "",
   onClick,
   direction = "left",
-}: PropsType) => {
+}: PropsType) {
   const rotate = {
     left: "rotate-[0deg]",
     up: "rotate-[90deg]",
@@ -38,4 +38,14 @@ export const Arrow = ({
       />
     </svg>
   );
+}
+
+Arrow.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
+  direction: "left",
 };
+
+export { Arrow };
+export default Arrow;

--- a/src/assets/Arrow_Double.tsx
+++ b/src/assets/Arrow_Double.tsx
@@ -5,12 +5,12 @@ interface PropsType {
   direction?: "left" | "up" | "right" | "down";
 }
 
-export const Arrow_Double = ({
+function ArrowDouble({
   size = 24,
   className = "",
   onClick,
   direction = "left",
-}: PropsType) => {
+}: PropsType) {
   const rotate = {
     left: "rotate-[0deg]",
     up: "rotate-[90deg]",
@@ -38,4 +38,14 @@ export const Arrow_Double = ({
       />
     </svg>
   );
+}
+
+ArrowDouble.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
+  direction: "left",
 };
+
+export { ArrowDouble as Arrow_Double };
+export default ArrowDouble;

--- a/src/assets/Arrow_Long.tsx
+++ b/src/assets/Arrow_Long.tsx
@@ -5,12 +5,12 @@ interface PropsType {
   direction?: "left" | "up" | "right" | "down";
 }
 
-export const Arrow_Long = ({
+function ArrowLong({
   size = 24,
   className = "",
   onClick,
   direction = "left",
-}: PropsType) => {
+}: PropsType) {
   const rotate = {
     right: "rotate-[0deg]",
     down: "rotate-[90deg]",
@@ -38,4 +38,14 @@ export const Arrow_Long = ({
       />
     </svg>
   );
+}
+
+ArrowLong.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
+  direction: "left",
 };
+
+export { ArrowLong as Arrow_Long };
+export default ArrowLong;

--- a/src/assets/Arrow_Short.tsx
+++ b/src/assets/Arrow_Short.tsx
@@ -5,12 +5,12 @@ interface PropsType {
   direction?: "left" | "right" | "up" | "down" | "upRight";
 }
 
-export const Arrow_Short = ({
+function ArrowShort({
   size = 24,
   className = "",
   onClick,
   direction = "left",
-}: PropsType) => {
+}: PropsType) {
   const rotate = {
     upRight: "rotate-[315deg]",
     right: "rotate-[0deg]",
@@ -39,4 +39,14 @@ export const Arrow_Short = ({
       />
     </svg>
   );
+}
+
+ArrowShort.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
+  direction: "left",
 };
+
+export { ArrowShort as Arrow_Short };
+export default ArrowShort;

--- a/src/assets/Book.tsx
+++ b/src/assets/Book.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Book = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Book({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Book = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Book.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Book };
+export default Book;

--- a/src/assets/Calendar.tsx
+++ b/src/assets/Calendar.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Calendar = ({ size = 24, onClick, className }: PropsType) => {
+function Calendar({ size = 24, onClick, className }: PropsType) {
   return (
     <svg
       width={size}
@@ -24,4 +24,13 @@ export const Calendar = ({ size = 24, onClick, className }: PropsType) => {
       />
     </svg>
   );
+}
+
+Calendar.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Calendar };
+export default Calendar;

--- a/src/assets/Check.tsx
+++ b/src/assets/Check.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Check = ({ size = 24, onClick, className }: PropsType) => {
+function Check({ size = 24, onClick, className }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Check = ({ size = 24, onClick, className }: PropsType) => {
       />
     </svg>
   );
+}
+
+Check.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Check };
+export default Check;

--- a/src/assets/Close.tsx
+++ b/src/assets/Close.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Close = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Close({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Close = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Close.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Close };
+export default Close;

--- a/src/assets/Discord.tsx
+++ b/src/assets/Discord.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Discord = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Discord({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -21,4 +21,13 @@ export const Discord = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Discord.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Discord };
+export default Discord;

--- a/src/assets/Document.tsx
+++ b/src/assets/Document.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Document = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Document({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Document = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Document.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Document };
+export default Document;

--- a/src/assets/Edit.tsx
+++ b/src/assets/Edit.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Edit = ({ size = 24, onClick, className }: PropsType) => {
+function Edit({ size = 24, onClick, className }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Edit = ({ size = 24, onClick, className }: PropsType) => {
       />
     </svg>
   );
+}
+
+Edit.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Edit };
+export default Edit;

--- a/src/assets/Github.tsx
+++ b/src/assets/Github.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Github = ({ size = 24, className = "", onClick }: PropsType) => {
+function Github({ size = 24, className = "", onClick }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -21,4 +21,13 @@ export const Github = ({ size = 24, className = "", onClick }: PropsType) => {
       />
     </svg>
   );
+}
+
+Github.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Github };
+export default Github;

--- a/src/assets/Hide.tsx
+++ b/src/assets/Hide.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Hide = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Hide({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Hide = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Hide.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Hide };
+export default Hide;

--- a/src/assets/Info.tsx
+++ b/src/assets/Info.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Info = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Info({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Info = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Info.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Info };
+export default Info;

--- a/src/assets/Instagram.tsx
+++ b/src/assets/Instagram.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Instagram = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function Instagram({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -37,4 +33,13 @@ export const Instagram = ({
       />
     </svg>
   );
+}
+
+Instagram.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Instagram };
+export default Instagram;

--- a/src/assets/Logo.tsx
+++ b/src/assets/Logo.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Logo = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Logo({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -23,4 +23,13 @@ export const Logo = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Logo.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Logo };
+export default Logo;

--- a/src/assets/More.tsx
+++ b/src/assets/More.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Close = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Close({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Close = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Close.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Close };
+export default Close;

--- a/src/assets/Notebook.tsx
+++ b/src/assets/Notebook.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Notebook = ({ size = 24, className = "", onClick }: PropsType) => {
+function Notebook({ size = 24, className = "", onClick }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Notebook = ({ size = 24, className = "", onClick }: PropsType) => {
       />
     </svg>
   );
+}
+
+Notebook.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Notebook };
+export default Notebook;

--- a/src/assets/Quotes.tsx
+++ b/src/assets/Quotes.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Quotes = ({ size = 24, className = "", onClick }: PropsType) => {
+function Quotes({ size = 24, className = "", onClick }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Quotes = ({ size = 24, className = "", onClick }: PropsType) => {
       />
     </svg>
   );
+}
+
+Quotes.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Quotes };
+export default Quotes;

--- a/src/assets/Search.tsx
+++ b/src/assets/Search.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Search = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Search({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Search = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Search.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Search };
+export default Search;

--- a/src/assets/Setting.tsx
+++ b/src/assets/Setting.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Setting = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Setting({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -31,4 +31,13 @@ export const Setting = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Setting.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Setting };
+export default Setting;

--- a/src/assets/Show.tsx
+++ b/src/assets/Show.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Show = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Show({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -31,4 +31,13 @@ export const Show = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Show.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Show };
+export default Show;

--- a/src/assets/Slash.tsx
+++ b/src/assets/Slash.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Slash = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Slash({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Slash = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Slash.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Slash };
+export default Slash;

--- a/src/assets/TeamLogo.tsx
+++ b/src/assets/TeamLogo.tsx
@@ -3,82 +3,92 @@ interface PropsType {
   className?: string;
 }
 
-export const TeamLogo = ({ size, className }: PropsType) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 240 240"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <rect width="240" height="240" rx="28.8" fill="#D9F99D" />
-    <path
-      d="M78.75 70.1057H52.5V101.255H98.1562V89.2548M98.1562 113.255V70.1057V89.2548M98.1562 89.2548H119.25V113.255V62.4609"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <rect
-      x="108.75"
-      y="40.5"
-      width="21"
-      height="21"
-      rx="10.5"
-      stroke="white"
-      strokeWidth="12"
-    />
-    <path
-      d="M175.406 163.155V156.006M175.406 182.8V132.006V156.006M175.406 156.006H192M156 139.651H129.75V170.8H156V139.651Z"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <rect
-      x="192.75"
-      y="144.545"
-      width="21"
-      height="21"
-      rx="10.5"
-      stroke="white"
-      strokeWidth="12"
-    />
-    <path
-      d="M53.25 159H107.25"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M53.25 180H107.25"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M141 91.5H174"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M141 112.5H174"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M53.25 139.506H155.25"
-      stroke="white"
-      strokeWidth="12"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
+function TeamLogo({ size, className }: PropsType) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 240 240"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect width="240" height="240" rx="28.8" fill="#D9F99D" />
+      <path
+        d="M78.75 70.1057H52.5V101.255H98.1562V89.2548M98.1562 113.255V70.1057V89.2548M98.1562 89.2548H119.25V113.255V62.4609"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <rect
+        x="108.75"
+        y="40.5"
+        width="21"
+        height="21"
+        rx="10.5"
+        stroke="white"
+        strokeWidth="12"
+      />
+      <path
+        d="M175.406 163.155V156.006M175.406 182.8V132.006V156.006M175.406 156.006H192M156 139.651H129.75V170.8H156V139.651Z"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <rect
+        x="192.75"
+        y="144.545"
+        width="21"
+        height="21"
+        rx="10.5"
+        stroke="white"
+        strokeWidth="12"
+      />
+      <path
+        d="M53.25 159H107.25"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M53.25 180H107.25"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M141 91.5H174"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M141 112.5H174"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M53.25 139.506H155.25"
+        stroke="white"
+        strokeWidth="12"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+TeamLogo.defaultProps = {
+  size: 24,
+  className: "",
+};
+
+export { TeamLogo };
+export default TeamLogo;

--- a/src/assets/Text.tsx
+++ b/src/assets/Text.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Text({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Text = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Text.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { Text };
+export default Text;

--- a/src/assets/Text_Bold.tsx
+++ b/src/assets/Text_Bold.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text_Bold = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function TextBold({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,4 +24,13 @@ export const Text_Bold = ({
       />
     </svg>
   );
+}
+
+TextBold.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { TextBold as Text_Bold };
+export default TextBold;

--- a/src/assets/Text_Italic.tsx
+++ b/src/assets/Text_Italic.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text_Italic = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function TextItalic({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,4 +24,13 @@ export const Text_Italic = ({
       />
     </svg>
   );
+}
+
+TextItalic.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { TextItalic as Text_Italic };
+export default TextItalic;

--- a/src/assets/Text_Link.tsx
+++ b/src/assets/Text_Link.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text_Link = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function TextLink({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,4 +24,13 @@ export const Text_Link = ({
       />
     </svg>
   );
+}
+
+TextLink.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { TextLink as Text_Link };
+export default TextLink;

--- a/src/assets/Text_Strikethrough.tsx
+++ b/src/assets/Text_Strikethrough.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text_Strikethrough = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function TextStrikethrough({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,4 +24,13 @@ export const Text_Strikethrough = ({
       />
     </svg>
   );
+}
+
+TextStrikethrough.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { TextStrikethrough as Text_Strikethrough };
+export default TextStrikethrough;

--- a/src/assets/Text_Underline.tsx
+++ b/src/assets/Text_Underline.tsx
@@ -4,11 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const Text_Underline = ({
-  size = 24,
-  onClick,
-  className = "",
-}: PropsType) => {
+function TextUnderline({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,4 +24,13 @@ export const Text_Underline = ({
       />
     </svg>
   );
+}
+
+TextUnderline.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { TextUnderline as Text_Underline };
+export default TextUnderline;

--- a/src/assets/User.tsx
+++ b/src/assets/User.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-export const User = ({ size = 24, className = "", onClick }: PropsType) => {
+function User({ size = 24, className = "", onClick }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const User = ({ size = 24, className = "", onClick }: PropsType) => {
       />
     </svg>
   );
+}
+
+User.defaultProps = {
+  size: 24,
+  className: "",
+  onClick: undefined,
 };
+
+export { User };
+export default User;

--- a/src/assets/Warn.tsx
+++ b/src/assets/Warn.tsx
@@ -4,7 +4,7 @@ interface PropsType {
   className?: string;
 }
 
-export const Warn = ({ size = 24, onClick, className = "" }: PropsType) => {
+function Warn({ size = 24, onClick, className = "" }: PropsType) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,4 +24,13 @@ export const Warn = ({ size = 24, onClick, className = "" }: PropsType) => {
       />
     </svg>
   );
+}
+
+Warn.defaultProps = {
+  size: 24,
+  onClick: undefined,
+  className: "",
 };
+
+export { Warn };
+export default Warn;


### PR DESCRIPTION
## Summary
- `src/assets` 전체 아이콘 컴포넌트를 함수 선언형 + default export 구조로 정리해 `react/function-component-definition`, `import/prefer-default-export` 규칙을 해소했습니다.
- optional props에 `defaultProps`를 일괄 보강해 `react/require-default-props` 오류를 해소했습니다.
- underscore 이름 아이콘(`Arrow_Double`, `Text_Bold` 등)은 내부 식별자는 PascalCase로 정리하고 기존 export 이름은 alias로 유지해 사용처 호환성을 유지했습니다.

## Verification
- yarn next lint --dir src/assets
- yarn tsc --noEmit