### PR TITLE
chore :: category/index 컴포넌트 lint 오류 정리

### DIFF
--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -2,21 +2,24 @@ interface CategoryProps {
   groups: string[][];
 }
 
-const Category = ({ groups }: CategoryProps) => {
+function Category({ groups }: CategoryProps) {
   const renderGroups = () => {
-    const formatGroups = groups.map((group, index) => {
-      const format = group.map((item, index) => {
-        const isLastItem = index === group.length - 1;
+    const formatGroups = groups.map((group, groupIndex) => {
+      const format = group.map((item, itemIndex) => {
+        const isLastItem = itemIndex === group.length - 1;
         return (
-          <span className="text-myDocumentNameColor flex gap-[6px]">
+          <span
+            key={`${group.join("-")}-${item}`}
+            className="text-myDocumentNameColor flex gap-[6px]"
+          >
             {`${item}`}
             <span>{isLastItem ? "" : "/"}</span>
           </span>
         );
       });
-      const isLastGroup = index === groups.length - 1;
+      const isLastGroup = groupIndex === groups.length - 1;
       return (
-        <span className="flex gap-[10px]">
+        <span key={group.join("-")} className="flex gap-[10px]">
           <span className="flex gap-[6px]">{format}</span>
           {isLastGroup ? "" : "|"}
         </span>
@@ -30,6 +33,6 @@ const Category = ({ groups }: CategoryProps) => {
       {renderGroups()}
     </div>
   );
-};
+}
 
 export default Category;

--- a/src/components/index/index.tsx
+++ b/src/components/index/index.tsx
@@ -5,15 +5,13 @@ interface IndexProps {
   index: IndexItem[];
 }
 
-const Index = ({ index }: IndexProps) => {
+function Index({ index }: IndexProps) {
   const rernderIndex = (indexObject: IndexItem[]) => {
-    return indexObject.map((item, index) => {
+    return indexObject.map(item => {
       return (
-        <Link href={`#${item.title}`}>
+        <Link key={item.index} href={`#${item.title}`}>
           <div className="text-[18px] border-l-2 border-l-transparent hover:border-l-[#93CB56] hover:bg-[#F5F5F5] pl-[10px] hover:cursor-pointer">
-            <span key={index} className="text-[#93DF3F]">
-              {item.index}
-            </span>
+            <span className="text-[#93DF3F]">{item.index}</span>
             <span>{`. ${item.title}`}</span>
           </div>
         </Link>
@@ -26,6 +24,6 @@ const Index = ({ index }: IndexProps) => {
       <div className="flex flex-col gap-[2px]">{rernderIndex(index)}</div>
     </div>
   );
-};
+}
 
 export default Index;


### PR DESCRIPTION
## Summary
- `src/components/category.tsx`의 map 렌더링 key 누락/중복 변수명 문제를 정리했습니다.
- `src/components/index/index.tsx`의 map key 누락과 인덱스 키 사용 문제를 정리했습니다.
- 두 컴포넌트를 함수 선언형으로 정리해 컴포넌트 정의 규칙을 맞췄습니다.

## Verification
- yarn next lint --file "src/components/category.tsx" --file "src/components/index/index.tsx"
- yarn tsc --noEmit